### PR TITLE
Changed imm into a std::optional & removed DEADBEEF.

### DIFF
--- a/shared/utils/il2cpp-functions.cpp
+++ b/shared/utils/il2cpp-functions.cpp
@@ -496,45 +496,47 @@ void il2cpp_functions::Init() {
     // XREF TRACES
     // Class::Init. 0x846A68 in 1.5, 0x9EC0A4 in 1.7.0, 0xA6D1B8 in 1.8.0b1
     Instruction ans((const int32_t*)array_new_specific);
-    Instruction Array_NewSpecific((const int32_t*)ans.imm);
+    Instruction Array_NewSpecific((const int32_t*)*CRASH_UNLESS(ans.imm));
     log(DEBUG, "Array::NewSpecific offset: %llX", ((long long)Array_NewSpecific.addr) - getRealOffset(0));
     auto j2Cl_I = CRASH_UNLESS(Array_NewSpecific.findNthCall(1));  // also the 113th call in Runtime::Init
-    Class_Init = (decltype(Class_Init))j2Cl_I->imm;
+    Class_Init = (decltype(Class_Init))*CRASH_UNLESS(j2Cl_I->imm);
     log(DEBUG, "Class::Init found? offset: %llX", ((long long)Class_Init) - getRealOffset(0));
 
     // MetadataCache::GetTypeInfoFromTypeIndex. offset 0x84F764 in 1.5, 0x9F5250 in 1.7.0, 0xA7A79C in 1.8.0b1
     Instruction caha((const int32_t*)custom_attrs_has_attr);
-    Instruction MetadataCache_HasAttribute((const int32_t*)caha.imm);
+    Instruction MetadataCache_HasAttribute((const int32_t*)*CRASH_UNLESS(caha.imm));
     auto j2MC_GTIFTI = CRASH_UNLESS(MetadataCache_HasAttribute.findNthCall(1));
-    MetadataCache_GetTypeInfoFromTypeIndex = (decltype(MetadataCache_GetTypeInfoFromTypeIndex))j2MC_GTIFTI->imm;
+    MetadataCache_GetTypeInfoFromTypeIndex = (decltype(MetadataCache_GetTypeInfoFromTypeIndex))*CRASH_UNLESS(j2MC_GTIFTI->imm);
     log(DEBUG, "MetadataCache::GetTypeInfoFromTypeIndex found? offset: %llX",
         ((long long)MetadataCache_GetTypeInfoFromTypeIndex) - getRealOffset(0));
 
     // MetadataCache::GetTypeInfoFromTypeDefinitionIndex. offset 0x84FBA4 in 1.5, 0x9F5690 in 1.7.0, 0xA75958 in 1.8.0b1
     Instruction tgcoec((const int32_t*)type_get_class_or_element_class);
-    Instruction Type_GetClassOrElementClass((const int32_t*)tgcoec.imm);
+    Instruction Type_GetClassOrElementClass((const int32_t*)*CRASH_UNLESS(tgcoec.imm));
     auto j2MC_GTIFTDI = CRASH_UNLESS(Type_GetClassOrElementClass.findNthDirectBranchWithoutLink(5));
-    MetadataCache_GetTypeInfoFromTypeDefinitionIndex = (decltype(MetadataCache_GetTypeInfoFromTypeDefinitionIndex))j2MC_GTIFTDI->imm;
+    MetadataCache_GetTypeInfoFromTypeDefinitionIndex =
+        (decltype(MetadataCache_GetTypeInfoFromTypeDefinitionIndex))*CRASH_UNLESS(j2MC_GTIFTDI->imm);
     log(DEBUG, "MetadataCache::GetTypeInfoFromTypeDefinitionIndex found? offset: %llX",
         ((long long)MetadataCache_GetTypeInfoFromTypeDefinitionIndex) - getRealOffset(0));
 
     // Type::GetName. offset 0x8735DC in 1.5, 0xA1A458 in 1.7.0, 0xA7B634 in 1.8.0b1
     Instruction tanq((const int32_t*)type_get_assembly_qualified_name);
-    _Type_GetName_ = (decltype(_Type_GetName_))tanq.findNthCall(1)->imm;
+    auto j2T_GN = CRASH_UNLESS(tanq.findNthCall(1));
+    _Type_GetName_ = (decltype(_Type_GetName_))*CRASH_UNLESS(j2T_GN->imm);
     log(DEBUG, "Type::GetName found? offset: %llX", ((long long)_Type_GetName_) - getRealOffset(0));
 
     // GenericClass::GetClass. offset 0x88DF64 in 1.5, 0xA34F20 in 1.7.0, 0xA6E4EC in 1.8.0b1
     Instruction cfit((const int32_t*)class_from_il2cpp_type);
-    Instruction Class_FromIl2CppType((const int32_t*)cfit.imm);
+    Instruction Class_FromIl2CppType((const int32_t*)*CRASH_UNLESS(cfit.imm));
     auto caseStart = CRASH_UNLESS(EvalSwitch(Class_FromIl2CppType.addr, 1, 1, IL2CPP_TYPE_GENERICINST));
     auto j2GC_GC = CRASH_UNLESS(caseStart->findNthDirectBranchWithoutLink(1));
     log(DEBUG, "j2GC_GC: %s", j2GC_GC->toString().c_str());
-    GenericClass_GetClass = (decltype(GenericClass_GetClass))j2GC_GC->imm;
+    GenericClass_GetClass = (decltype(GenericClass_GetClass))*CRASH_UNLESS(j2GC_GC->imm);
     log(DEBUG, "GenericClass::GetClass found? offset: %llX", ((long long)GenericClass_GetClass) - getRealOffset(0));
 
     Instruction iu16((const int32_t*)init_utf16);
     auto j2R_I = CRASH_UNLESS(iu16.findNthCall(3));
-    Instruction Runtime_Init((const int32_t*)j2R_I->imm);
+    Instruction Runtime_Init((const int32_t*)*CRASH_UNLESS(j2R_I->imm));
     auto ldr = CRASH_UNLESS(Runtime_Init.findNth(1, std::mem_fn(&Instruction::isLoad)));  // the load for the malloc that precedes our adrp
     // alternatively, could just get the 1st ADRP in Runtime::Init with dest reg x20
     il2cpp_functions::defaults = (decltype(il2cpp_functions::defaults))ExtractAddress(ldr->addr, 1, 1);

--- a/shared/utils/instruction-parsing.hpp
+++ b/shared/utils/instruction-parsing.hpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <bitset>
+#include <optional>
 #include <stack>
 
 class Register {
@@ -29,10 +30,10 @@ public:
     int_fast8_t Rd2 = -2;  // the 2nd destination register's number, or -1 if none
     int_fast8_t numSourceRegisters = -1;  // the number of source registers this instruction has
     union {
-        int_fast8_t Rs[2] = { -1, -1 };  // the number(s) of the source register(s), e.g. {12, 31} for X12 & SP
+        int_fast8_t Rs[3] = { -1, -1, -1 };  // the number(s) of the source register(s), e.g. {12, 29} for X12 & X29
         int64_t result;  // iff numSourceRegisters is 0, the value that will be stored to Rd by this instruction
     };
-    int64_t imm = 0xDEADBEEF;  // the immediate, if applicable
+    std::optional<int64_t> imm;  // the immediate, if applicable
 
     // see https://developer.arm.com/docs/ddi0596/a/a64-shared-pseudocode-functions/aarch64-instrs-pseudocode#impl-aarch64.ShiftReg.3
     enum ShiftType {  // in most cases (exceptiing noShift) the amount is stored in imm and the shift is applied to Rm (Rs[1])


### PR DESCRIPTION
imm previously defaulted to DEADBEEF because it was the least likely value of an imm I could think of, but it is (probably) theoretically a valid value!
Hence, imm has been changed to a std::optional, so that we know when the value it contains is actually meaningful, regardless of what that value is.

Additional changes:
Added "Data-processing (3 source)" parsing.