### PR TITLE
Changed all jump/adrp imm to their proper name, label. long long -> intptr_t migration.

### DIFF
--- a/shared/utils/il2cpp-functions.cpp
+++ b/shared/utils/il2cpp-functions.cpp
@@ -491,69 +491,78 @@ void il2cpp_functions::Init() {
     log(INFO, "Loaded: il2cpp_class_get_type CONST VERSION!");
     *(void**)(&il2cpp_functions::class_get_name_const) = dlsym(imagehandle, "il2cpp_class_get_name");
     log(INFO, "Loaded: il2cpp_class_get_name CONST VERSION!");
-    usleep(5000L);  // 0.005s
 
     // XREF TRACES
     // Class::Init. 0x846A68 in 1.5, 0x9EC0A4 in 1.7.0, 0xA6D1B8 in 1.8.0b1
     Instruction ans((const int32_t*)array_new_specific);
-    Instruction Array_NewSpecific((const int32_t*)*CRASH_UNLESS(ans.imm));
+    Instruction Array_NewSpecific(*CRASH_UNLESS(ans.label));
     log(DEBUG, "Array::NewSpecific offset: %llX", ((long long)Array_NewSpecific.addr) - getRealOffset(0));
     auto j2Cl_I = CRASH_UNLESS(Array_NewSpecific.findNthCall(1));  // also the 113th call in Runtime::Init
-    Class_Init = (decltype(Class_Init))*CRASH_UNLESS(j2Cl_I->imm);
+    Class_Init = (decltype(Class_Init))*CRASH_UNLESS(j2Cl_I->label);
     log(DEBUG, "Class::Init found? offset: %llX", ((long long)Class_Init) - getRealOffset(0));
+    usleep(1000);  // 0.001s
 
     // MetadataCache::GetTypeInfoFromTypeIndex. offset 0x84F764 in 1.5, 0x9F5250 in 1.7.0, 0xA7A79C in 1.8.0b1
     Instruction caha((const int32_t*)custom_attrs_has_attr);
-    Instruction MetadataCache_HasAttribute((const int32_t*)*CRASH_UNLESS(caha.imm));
+    Instruction MetadataCache_HasAttribute(*CRASH_UNLESS(caha.label));
     auto j2MC_GTIFTI = CRASH_UNLESS(MetadataCache_HasAttribute.findNthCall(1));
-    MetadataCache_GetTypeInfoFromTypeIndex = (decltype(MetadataCache_GetTypeInfoFromTypeIndex))*CRASH_UNLESS(j2MC_GTIFTI->imm);
+    MetadataCache_GetTypeInfoFromTypeIndex = (decltype(MetadataCache_GetTypeInfoFromTypeIndex))*CRASH_UNLESS(j2MC_GTIFTI->label);
     log(DEBUG, "MetadataCache::GetTypeInfoFromTypeIndex found? offset: %llX",
         ((long long)MetadataCache_GetTypeInfoFromTypeIndex) - getRealOffset(0));
+    usleep(1000);  // 0.001s
 
     // MetadataCache::GetTypeInfoFromTypeDefinitionIndex. offset 0x84FBA4 in 1.5, 0x9F5690 in 1.7.0, 0xA75958 in 1.8.0b1
     Instruction tgcoec((const int32_t*)type_get_class_or_element_class);
-    Instruction Type_GetClassOrElementClass((const int32_t*)*CRASH_UNLESS(tgcoec.imm));
+    Instruction Type_GetClassOrElementClass(*CRASH_UNLESS(tgcoec.label));
     auto j2MC_GTIFTDI = CRASH_UNLESS(Type_GetClassOrElementClass.findNthDirectBranchWithoutLink(5));
     MetadataCache_GetTypeInfoFromTypeDefinitionIndex =
-        (decltype(MetadataCache_GetTypeInfoFromTypeDefinitionIndex))*CRASH_UNLESS(j2MC_GTIFTDI->imm);
+        (decltype(MetadataCache_GetTypeInfoFromTypeDefinitionIndex))*CRASH_UNLESS(j2MC_GTIFTDI->label);
     log(DEBUG, "MetadataCache::GetTypeInfoFromTypeDefinitionIndex found? offset: %llX",
         ((long long)MetadataCache_GetTypeInfoFromTypeDefinitionIndex) - getRealOffset(0));
+    usleep(1000);  // 0.001s
 
     // Type::GetName. offset 0x8735DC in 1.5, 0xA1A458 in 1.7.0, 0xA7B634 in 1.8.0b1
     Instruction tanq((const int32_t*)type_get_assembly_qualified_name);
     auto j2T_GN = CRASH_UNLESS(tanq.findNthCall(1));
-    _Type_GetName_ = (decltype(_Type_GetName_))*CRASH_UNLESS(j2T_GN->imm);
+    _Type_GetName_ = (decltype(_Type_GetName_))*CRASH_UNLESS(j2T_GN->label);
     log(DEBUG, "Type::GetName found? offset: %llX", ((long long)_Type_GetName_) - getRealOffset(0));
+    usleep(1000);  // 0.001s
 
     // GenericClass::GetClass. offset 0x88DF64 in 1.5, 0xA34F20 in 1.7.0, 0xA6E4EC in 1.8.0b1
     Instruction cfit((const int32_t*)class_from_il2cpp_type);
-    Instruction Class_FromIl2CppType((const int32_t*)*CRASH_UNLESS(cfit.imm));
+    Instruction Class_FromIl2CppType(*CRASH_UNLESS(cfit.label));
     auto caseStart = CRASH_UNLESS(EvalSwitch(Class_FromIl2CppType.addr, 1, 1, IL2CPP_TYPE_GENERICINST));
     auto j2GC_GC = CRASH_UNLESS(caseStart->findNthDirectBranchWithoutLink(1));
     log(DEBUG, "j2GC_GC: %s", j2GC_GC->toString().c_str());
-    GenericClass_GetClass = (decltype(GenericClass_GetClass))*CRASH_UNLESS(j2GC_GC->imm);
+    GenericClass_GetClass = (decltype(GenericClass_GetClass))*CRASH_UNLESS(j2GC_GC->label);
     log(DEBUG, "GenericClass::GetClass found? offset: %llX", ((long long)GenericClass_GetClass) - getRealOffset(0));
+    usleep(1000);  // 0.001s
 
     Instruction iu16((const int32_t*)init_utf16);
     auto j2R_I = CRASH_UNLESS(iu16.findNthCall(3));
-    Instruction Runtime_Init((const int32_t*)*CRASH_UNLESS(j2R_I->imm));
+    Instruction Runtime_Init(*CRASH_UNLESS(j2R_I->label));
     auto ldr = CRASH_UNLESS(Runtime_Init.findNth(1, std::mem_fn(&Instruction::isLoad)));  // the load for the malloc that precedes our adrp
     // alternatively, could just get the 1st ADRP in Runtime::Init with dest reg x20
     il2cpp_functions::defaults = (decltype(il2cpp_functions::defaults))ExtractAddress(ldr->addr, 1, 1);
     log(DEBUG, "il2cpp_defaults found? offset: %llX", ((long long)defaults) - getRealOffset(0));
+    usleep(1000);  // 0.001s
 
     // FIELDS
     // Extract locations of s_GlobalMetadataHeader, s_Il2CppMetadataRegistration, & s_GlobalMetadata
     // TODO: refactor to reduce instruction re-parsing?
-    il2cpp_functions::s_GlobalMetadataHeaderPtr = (decltype(il2cpp_functions::s_GlobalMetadataHeaderPtr))ExtractAddress(
-        il2cpp_functions::MetadataCache_GetTypeInfoFromTypeDefinitionIndex, 3, 1);
-    il2cpp_functions::s_Il2CppMetadataRegistrationPtr = (decltype(il2cpp_functions::s_Il2CppMetadataRegistrationPtr))ExtractAddress(
-        il2cpp_functions::MetadataCache_GetTypeInfoFromTypeDefinitionIndex, 4, 1);
-    il2cpp_functions::s_GlobalMetadataPtr = (decltype(il2cpp_functions::s_GlobalMetadataPtr))ExtractAddress(
-        il2cpp_functions::MetadataCache_GetTypeInfoFromTypeDefinitionIndex, 5, 1);
+    il2cpp_functions::s_GlobalMetadataHeaderPtr = (decltype(il2cpp_functions::s_GlobalMetadataHeaderPtr))CRASH_UNLESS(
+        ExtractAddress(il2cpp_functions::MetadataCache_GetTypeInfoFromTypeDefinitionIndex, 3, 1));
+    usleep(1000);  // 0.001s
+    il2cpp_functions::s_Il2CppMetadataRegistrationPtr = (decltype(il2cpp_functions::s_Il2CppMetadataRegistrationPtr))CRASH_UNLESS(
+        ExtractAddress(il2cpp_functions::MetadataCache_GetTypeInfoFromTypeDefinitionIndex, 4, 1));
+    usleep(1000);  // 0.001s
+    il2cpp_functions::s_GlobalMetadataPtr = (decltype(il2cpp_functions::s_GlobalMetadataPtr))CRASH_UNLESS(
+        ExtractAddress(il2cpp_functions::MetadataCache_GetTypeInfoFromTypeDefinitionIndex, 5, 1));
+    usleep(1000);  // 0.001s
+    log(DEBUG, "All global constants found!");
 
     dlclose(imagehandle);
     initialized = true;
-    usleep(5000L);  // 0.005s
     log(INFO, "il2cpp_functions: Init: Successfully loaded all il2cpp functions!");
+    usleep(100);  // 0.0001s
 }

--- a/shared/utils/il2cpp-functions.cpp
+++ b/shared/utils/il2cpp-functions.cpp
@@ -496,10 +496,10 @@ void il2cpp_functions::Init() {
     // Class::Init. 0x846A68 in 1.5, 0x9EC0A4 in 1.7.0, 0xA6D1B8 in 1.8.0b1
     Instruction ans((const int32_t*)array_new_specific);
     Instruction Array_NewSpecific(*CRASH_UNLESS(ans.label));
-    log(DEBUG, "Array::NewSpecific offset: %llX", ((long long)Array_NewSpecific.addr) - getRealOffset(0));
+    log(DEBUG, "Array::NewSpecific offset: %lX", ((intptr_t)Array_NewSpecific.addr) - getRealOffset(0));
     auto j2Cl_I = CRASH_UNLESS(Array_NewSpecific.findNthCall(1));  // also the 113th call in Runtime::Init
     Class_Init = (decltype(Class_Init))*CRASH_UNLESS(j2Cl_I->label);
-    log(DEBUG, "Class::Init found? offset: %llX", ((long long)Class_Init) - getRealOffset(0));
+    log(DEBUG, "Class::Init found? offset: %lX", ((intptr_t)Class_Init) - getRealOffset(0));
     usleep(1000);  // 0.001s
 
     // MetadataCache::GetTypeInfoFromTypeIndex. offset 0x84F764 in 1.5, 0x9F5250 in 1.7.0, 0xA7A79C in 1.8.0b1
@@ -507,8 +507,8 @@ void il2cpp_functions::Init() {
     Instruction MetadataCache_HasAttribute(*CRASH_UNLESS(caha.label));
     auto j2MC_GTIFTI = CRASH_UNLESS(MetadataCache_HasAttribute.findNthCall(1));
     MetadataCache_GetTypeInfoFromTypeIndex = (decltype(MetadataCache_GetTypeInfoFromTypeIndex))*CRASH_UNLESS(j2MC_GTIFTI->label);
-    log(DEBUG, "MetadataCache::GetTypeInfoFromTypeIndex found? offset: %llX",
-        ((long long)MetadataCache_GetTypeInfoFromTypeIndex) - getRealOffset(0));
+    log(DEBUG, "MetadataCache::GetTypeInfoFromTypeIndex found? offset: %lX",
+        ((intptr_t)MetadataCache_GetTypeInfoFromTypeIndex) - getRealOffset(0));
     usleep(1000);  // 0.001s
 
     // MetadataCache::GetTypeInfoFromTypeDefinitionIndex. offset 0x84FBA4 in 1.5, 0x9F5690 in 1.7.0, 0xA75958 in 1.8.0b1
@@ -517,15 +517,15 @@ void il2cpp_functions::Init() {
     auto j2MC_GTIFTDI = CRASH_UNLESS(Type_GetClassOrElementClass.findNthDirectBranchWithoutLink(5));
     MetadataCache_GetTypeInfoFromTypeDefinitionIndex =
         (decltype(MetadataCache_GetTypeInfoFromTypeDefinitionIndex))*CRASH_UNLESS(j2MC_GTIFTDI->label);
-    log(DEBUG, "MetadataCache::GetTypeInfoFromTypeDefinitionIndex found? offset: %llX",
-        ((long long)MetadataCache_GetTypeInfoFromTypeDefinitionIndex) - getRealOffset(0));
+    log(DEBUG, "MetadataCache::GetTypeInfoFromTypeDefinitionIndex found? offset: %lX",
+        ((intptr_t)MetadataCache_GetTypeInfoFromTypeDefinitionIndex) - getRealOffset(0));
     usleep(1000);  // 0.001s
 
     // Type::GetName. offset 0x8735DC in 1.5, 0xA1A458 in 1.7.0, 0xA7B634 in 1.8.0b1
     Instruction tanq((const int32_t*)type_get_assembly_qualified_name);
     auto j2T_GN = CRASH_UNLESS(tanq.findNthCall(1));
     _Type_GetName_ = (decltype(_Type_GetName_))*CRASH_UNLESS(j2T_GN->label);
-    log(DEBUG, "Type::GetName found? offset: %llX", ((long long)_Type_GetName_) - getRealOffset(0));
+    log(DEBUG, "Type::GetName found? offset: %lX", ((intptr_t)_Type_GetName_) - getRealOffset(0));
     usleep(1000);  // 0.001s
 
     // GenericClass::GetClass. offset 0x88DF64 in 1.5, 0xA34F20 in 1.7.0, 0xA6E4EC in 1.8.0b1
@@ -535,7 +535,7 @@ void il2cpp_functions::Init() {
     auto j2GC_GC = CRASH_UNLESS(caseStart->findNthDirectBranchWithoutLink(1));
     log(DEBUG, "j2GC_GC: %s", j2GC_GC->toString().c_str());
     GenericClass_GetClass = (decltype(GenericClass_GetClass))*CRASH_UNLESS(j2GC_GC->label);
-    log(DEBUG, "GenericClass::GetClass found? offset: %llX", ((long long)GenericClass_GetClass) - getRealOffset(0));
+    log(DEBUG, "GenericClass::GetClass found? offset: %lX", ((intptr_t)GenericClass_GetClass) - getRealOffset(0));
     usleep(1000);  // 0.001s
 
     Instruction iu16((const int32_t*)init_utf16);
@@ -544,7 +544,7 @@ void il2cpp_functions::Init() {
     auto ldr = CRASH_UNLESS(Runtime_Init.findNth(1, std::mem_fn(&Instruction::isLoad)));  // the load for the malloc that precedes our adrp
     // alternatively, could just get the 1st ADRP in Runtime::Init with dest reg x20
     il2cpp_functions::defaults = (decltype(il2cpp_functions::defaults))ExtractAddress(ldr->addr, 1, 1);
-    log(DEBUG, "il2cpp_defaults found? offset: %llX", ((long long)defaults) - getRealOffset(0));
+    log(DEBUG, "il2cpp_defaults found? offset: %lX", ((intptr_t)defaults) - getRealOffset(0));
     usleep(1000);  // 0.001s
 
     // FIELDS

--- a/shared/utils/il2cpp-utils.cpp
+++ b/shared/utils/il2cpp-utils.cpp
@@ -690,7 +690,7 @@ namespace il2cpp_utils {
     static std::unordered_map<Il2CppClass*, std::map<std::string, Il2CppGenericClass*, doj::alphanum_less<std::string>>> classToGenericClassMap;
     void BuildGenericsMap() {
         auto metadataReg = RET_V_UNLESS(*il2cpp_functions::s_Il2CppMetadataRegistrationPtr);
-        log(DEBUG, "metadataReg: %p, offset = %llX", metadataReg, ((long long)metadataReg) - getRealOffset(nullptr));
+        log(DEBUG, "metadataReg: %p, offset = %lX", metadataReg, ((intptr_t)metadataReg) - getRealOffset(0));
 
         int uncached_class_count = 0;
         for (int i=0; i < metadataReg->genericClassesCount; i++) {

--- a/shared/utils/instruction-parsing.cpp
+++ b/shared/utils/instruction-parsing.cpp
@@ -63,8 +63,8 @@ decltype(Instruction::result) ExtractAddressFixed(const int32_t* inst, int idxOf
 Instruction* EvalSwitch(const uint32_t* switchTable, int switchCaseValue) {
     auto stOffset = SignExtend<int64_t>(switchTable[switchCaseValue - 1], 32);
     auto jmpAddr = (int64_t)switchTable + stOffset;
-    log(DEBUG, "jmp offset from switch table: %lX (-%lX); jmp: %lX (offset %llX)",
-        stOffset, -stOffset, jmpAddr, jmpAddr - getRealOffset(0));
+    log(DEBUG, "jmp offset from switch table: %lX (-%lX); jmp: %lX (offset %lX)",
+        stOffset, -stOffset, jmpAddr, asOffset(jmpAddr));
     return new Instruction((const int32_t*)jmpAddr);
 }
 
@@ -107,9 +107,13 @@ std::ostream& operator<<(std::ostream& os, const Instruction& inst) {
     if (inst.parseLevel <= 0) return os << "Unparsable";
     os << '"' << inst.kind[inst.parseLevel - 1] << '"';
     if (inst.valid) {
-        if (inst.imm) os << ", imm: " << std::hex << *inst.imm;
         if (inst.Rd >= 0) os << ", destination register: " << Register(inst.Rd, inst.RdCanBeSP);
         if (inst.Rd2 >= 0) os << ", destination register 2: " << Register(inst.Rd2, inst.RdCanBeSP);
+        if (inst.imm) os << ", imm: " << std::hex << *inst.imm;
+        if (inst.label) os << ", label: " << std::hex << asOffset(*inst.label) << " (" << *inst.label << ")";
+        if (inst.branchType != Instruction::NOBRANCH) {
+            os << ", branch type: " << Instruction::branchTypeInfo[inst.branchType];
+        }
         if (inst.numSourceRegisters == 0) {
             if (inst.Rd >= 0) os << ", result: " << std::hex << inst.result;
         } else if (inst.numSourceRegisters > 0) {
@@ -119,9 +123,8 @@ std::ostream& operator<<(std::ostream& os, const Instruction& inst) {
                 os << Register(inst.Rs[j], j ? false : inst.Rs0CanBeSP);
             }
         }
-        if (inst.branchType != Instruction::NOBRANCH) {
-            os << ", branch type: " << Instruction::branchTypeInfo[inst.branchType];
-        }
+    } else {
+        os << ", marked invalid!";
     }
     return os << std::noshowbase;
 }
@@ -152,7 +155,7 @@ bool Instruction::isStore() {
 
 bool Instruction::hasImmOffsetOnReg(uint_fast8_t reg) {
     if (!imm) return false;
-    if (!(isLoadOrStore() || isAddOrSubImm())) return false;  // the immediate would not be simply "added"
+    if (! (isLoadOrStore() || isAddOrSubImm()) ) return false;  // the immediate would not be simply "added"
     if (isStore()) {
         return (Rd == reg) || (Rd2 == reg);
     }
@@ -180,14 +183,16 @@ Instruction* Instruction::findNthImmOffsetOnReg(int n, uint_fast8_t reg, int ret
 
 Instruction::Instruction(const int32_t* inst) {
     addr = inst;
-    auto pc = (unsigned long long)inst;
+    auto pc = (intptr_t)inst;
+    auto base = CRASH_UNLESS(getBase(pc));
+
     parseLevel = 0;
     parsed = false;
     auto code = *inst;
     // https://developer.arm.com/docs/ddi0596/a/top-level-encodings-for-a64#top
     uint_fast8_t top0 = bits(code, 28, 25);  // op0 for top-level only
-    log(DEBUG, "inst: ptr = 0x%llX (offset 0x%llX), bytes = 0x%X, top-level op0: %i",
-        pc, pc - getRealOffset(0), code, top0);
+    log(DEBUG, "inst: ptr = 0x%lX (offset 0x%lX), bytes = 0x%X, top-level op0: %i",
+        pc, pc - base, code, top0);
     // Bit patterns like 1x0x where x is any bit and all other bits must match are implemented by:
     // 1. (a & [1's where pattern has non-x]) == [pattern with x's as 0]
     // 2. (a | [1's where pattern has x])     == [pattern with x's as 1]
@@ -222,7 +227,7 @@ Instruction::Instruction(const int32_t* inst) {
                 uint_fast8_t opc = bits(code, 30, 29);
                 if (opc == 1) {
                     if (N == 0) {
-                        if ((shiftType == LSL) && (imm == 0) && Rn == RZR) {
+                        if ((shiftType == LSL) && (*imm == 0) && Rn == RZR) {
                             kind[parseLevel++] = "MOV (register)";  // preferred alias
                             if (Rm == RZR) {
                                 numSourceRegisters = 0;
@@ -310,7 +315,7 @@ Instruction::Instruction(const int32_t* inst) {
                         }
                     }
 
-                    if ((opt != 0) || (imm > 4)) {
+                    if ((opt != 0) || (*imm > 4)) {
                         kind[parseLevel++] = unalloc;
                     } else {
                         // TODO: if sf == 0, all regs are 32-bit views; else all are 64-bit except Rm is a 32-bit view iff option != x11
@@ -398,8 +403,8 @@ Instruction::Instruction(const int32_t* inst) {
                 }
 
                 bool o0 = bits(code, 15, 15);
-                auto op31 = bits(code, 23, 21);
-                auto op54 = bits(code, 30, 29);
+                auto op31 = bits(code, 23, 21);  // basically bits 2-0 of op
+                auto op54 = bits(code, 30, 29);  // bits 4-3 of op
                 if ((op54 != 0) || (op31 == 0b11) || (op31 == 0b100) || (op31 == 0b111) ||
                     ((o0 == 1) && ((op31 == 0b10) || (op31 == 0b110)) ) ||
                     ((sf == 0) && (op31 != 0))) {
@@ -488,9 +493,11 @@ Instruction::Instruction(const int32_t* inst) {
                 kind[parseLevel++] = "ADR";
             }
             log(DEBUG, "imm initial: 0x%X (%i); immNumBits: %i", immI, immI, immINumBits);
-            imm = SignExtend<int64_t>(immI, immINumBits);
-            result = pc + *imm;
-            log(DEBUG, "imm: 0x%lX; result: 0x%lX (offset 0x%llX)", *imm, result, result - getRealOffset(0));
+            // the documentation calls this imm, but it's not exposed in the instruction string
+            auto privateImm = SignExtend<int64_t>(immI, immINumBits);
+            result = pc + privateImm;
+            label = (decltype(label)::value_type) result;
+            log(DEBUG, "imm: 0x%lX; result: 0x%lX (offset 0x%lX)", privateImm, result, result - base);
         } else if (op0 == 0b1) {
             numSourceRegisters = 1;
             Rs0CanBeSP = true;
@@ -513,7 +520,7 @@ Instruction::Instruction(const int32_t* inst) {
                 imm = ZeroExtend<int64_t>(imm12, 12) << 12 * shift;
                 if (op == 0) {
                     if (S == 0) {
-                        if ((imm == 0) && ((Rd == SP) || (Rs[0] == SP))) {
+                        if ((*imm == 0) && ((Rd == SP) || (Rs[0] == SP))) {
                             // https://developer.arm.com/docs/ddi0596/a/a64-base-instructions-alphabetic-order/mov-tofrom-sp-move-between-register-and-stack-pointer-an-alias-of-add-immediate
                             kind[parseLevel++] = "MOV (to/from SP)";  // preferred alias
                         } else {
@@ -556,7 +563,7 @@ Instruction::Instruction(const int32_t* inst) {
                 uint_fast8_t Rn = bits(code, 9, 5);
                 imm = DecodeBitMasks(N, imms, immr, sf ? 64 : 32);
                 log(DEBUG, "N: %i, immr: 0x%X, imms: 0x%X, decoded imm: 0x%lX", N, immr, imms, *imm);
-                if (imm == -1) valid = false;
+                if (*imm == -1) valid = false;
 
                 if (Rn == RZR) {
                     numSourceRegisters = 0;
@@ -596,12 +603,25 @@ Instruction::Instruction(const int32_t* inst) {
                         kind[parseLevel++] = "ANDS (immediate) — 64-bit";
                     }
                 }
+            } else {
+                log(DEBUG, "sf: %i, op0 == 0b10, op1: %u", sf, op1);
             }
+        } else {
+            assert(op0 == 0b11);
+            if ((op1 & 0b10) == 0) {  // 0x
+                // https://developer.arm.com/docs/ddi0596/a/top-level-encodings-for-a64/data-processing-immediate#bitfield
+                kind[parseLevel++] = "Bitfield";
+            } else {  // op1 == 1x
+                // https://developer.arm.com/docs/ddi0596/a/top-level-encodings-for-a64/data-processing-immediate#extract
+                kind[parseLevel++] = "Extract";
+            }
+            log(DEBUG, "sf: %i, op0 == 3, op1: %u", sf, op1);
         }
     } else if ((top0 | 0b1) == 0b1011) {  // 101x
         // https://developer.arm.com/docs/ddi0596/a/top-level-encodings-for-a64/branches-exception-generating-and-system-instructions
         kind[parseLevel++] = "Branches, Exception Generating and System instructions";
         Rd = -1;
+        RdCanBeSP = Rs0CanBeSP = false;
         uint_fast8_t op0 = bits(code, 31, 29);
         uint_fast16_t op1 = bits(code, 25, 12);
         uint_fast8_t op2 = bits(code, 4, 0);
@@ -620,8 +640,8 @@ Instruction::Instruction(const int32_t* inst) {
                     kind[parseLevel++] = unalloc;
                 } else {
                     kind[parseLevel++] = "B.cond";
-                    imm = pc + (SignExtend<int64_t>(imm19, 19) << 2);
-                    log(DEBUG, "imm's offset: %llX", *imm - getRealOffset(0));
+                    label = (decltype(label)::value_type)(pc + (SignExtend<int64_t>(imm19, 19) << 2));
+                    log(DEBUG, "label: %lX", ((decltype(base))*label) - base);
                     branchType = DIR;
                 }
             }
@@ -630,10 +650,11 @@ Instruction::Instruction(const int32_t* inst) {
                 // https://developer.arm.com/docs/ddi0596/a/top-level-encodings-for-a64/branches-exception-generating-and-system-instructions#branch_reg
                 kind[parseLevel++] = "Unconditional branch (register)";
                 numSourceRegisters = 1;
+                Rs[0] = bits(code, 9, 5);
+
                 uint_fast8_t opc = bits(code, 24, 21);
                 uint_fast8_t op2 = bits(code, 20, 16);
                 uint_fast8_t op3 = bits(code, 15, 10);
-                Rs[0] = bits(code, 9, 5);
                 uint_fast8_t op4 = bits(code, 4, 0);
                 if (op2 != 0b11111) {
                     kind[parseLevel++] = unalloc;
@@ -685,12 +706,12 @@ Instruction::Instruction(const int32_t* inst) {
             bool op = bits(code, 31, 31);
             uint_fast32_t imm26 = bits(code, 25, 0);
             auto offset = SignExtend<int64_t>(imm26, 26) << 2;
-            imm = pc + offset;
+            label = (decltype(label)::value_type)(pc + offset);
 
-            auto off = *imm - getRealOffset(0);
-            log(DEBUG, "imm's offset: %llX", off);
-            if (off >= 0x03000000) {
-                log(ERROR, "0x%llX is probably not a valid offset! Please investigate!", off);
+            int64_t off = ((decltype(base))*label) - base;
+            log(DEBUG, "label: %lX", off);
+            if ((off < 0) || (off >= 0x03000000)) {
+                log(ERROR, "0x%lX is probably not a valid offset! Please investigate!", off);
             }
             if (!op) {
                 kind[parseLevel++] = "B";
@@ -701,8 +722,42 @@ Instruction::Instruction(const int32_t* inst) {
                 Rd = RLINK;
                 result = pc + 4;
             }
+        } else if ((op0 & 0b11) == 0b01) {  // x01
+            if ((op1 & 0b10000000000000) == 0) {  // 0xxxxxxxxxxxxx
+                // https://developer.arm.com/docs/ddi0596/a/top-level-encodings-for-a64/branches-exception-generating-and-system-instructions#compbranch
+                kind[parseLevel++] = "Compare and branch (immediate)";
+                numSourceRegisters = 1;
+                auto Rt = Rs[0] = bits(code, 4, 0);
+
+                bool sf = bits(code, 31, 31);
+                bool op = bits(code, 24, 24);
+                auto imm19 = bits(code, 23, 5);
+                // TODO: the only register (Rt) is viewed as 32-bit iff sf == 0
+                if (op == 0) {
+                    kind[parseLevel++] = sf ? "CBZ — 64-bit" : "CBZ — 32-bit";
+                } else {
+                    kind[parseLevel++] = sf ? "CBNZ — 64-bit" : "CBNZ — 32-bit";
+                }
+                label = (decltype(label)::value_type)(SignExtend<int64_t>(imm19, 19) << 2);
+            } else {  // op1 == 1xxxxxxxxxxxxx
+                // https://developer.arm.com/docs/ddi0596/a/top-level-encodings-for-a64/branches-exception-generating-and-system-instructions#testbranch
+                kind[parseLevel++] = "Test and branch (immediate)";
+                numSourceRegisters = 1;
+                auto Rt = Rs[0] = bits(code, 4, 0);
+
+                bool b5 = bits(code, 31, 31);
+                bool op = bits(code, 24, 24);
+                auto b40 = bits(code, 23, 19);
+                auto imm14 = bits(code, 18, 5);
+                // TODO: the only register (Rt) is viewed as 32-bit iff b5 == 0 (only matters in this case for pretty printing)
+
+                imm = (((int)b5) << 4) | ((int)b40);  // the bit index in Rt to test
+                branchType = DIR;
+                label = (decltype(label)::value_type)(pc + (SignExtend<int64_t>(imm14, 14) << 2));
+                kind[parseLevel++] = op ? "TBNZ" : "TBZ";
+            }
         } else {
-            log(DEBUG, "op0: %i", op0);
+            log(DEBUG, "op0: %u, op1: %s, op2: %u", op0, std::bitset<14>(op1).to_string().c_str(), op2);
         }
     } else if ((top0 & 0b101) == 0b100) {  // x1x0
         // https://developer.arm.com/docs/ddi0596/a/top-level-encodings-for-a64/loads-and-stores
@@ -757,11 +812,11 @@ Instruction::Instruction(const int32_t* inst) {
                     numSourceRegisters = 2;
                     auto Rm = Rs[1] = bits(code, 20, 16);  // cannot be SP
 
-                    extendType = static_cast<ExtendType>(bits(code, 15, 13));  // "option"
+                    extendType = static_cast<ExtendType>(bits(code, 15, 13));  // <extend>, encoded in "option"
                     bool S = bits(code, 12, 12);
                     bool shifted = (extendType == UXTX);
                     if (shifted) shiftType = LSL;
-                    imm = (S ? size : 0);
+                    imm = (S ? size : 0);  // <amount>
 
                     // TODO: when option & 0b1 == 0, Rm is a 32-bit view, else 64
                     // TODO: when opc & 0b10 == 0, Rt is a 32-bit view, else 32 iff opc & 0b1 == 1
@@ -1052,17 +1107,14 @@ void InstructionTree::PopulateChildren(ParseState& parseState) {
     // populate parseState.dependencyMap using this' dest and source registers
     ProcessRegisterDependencies(this, parseState.dependencyMap);
 
-    // if instruction is direct branch, branch's addr is imm
+    // if instruction is direct branch, address to jump to is in "label"
     if (isDirectBranch()) {
-        if (imm) {
-            auto immAsAddr = (const int32_t*)*imm;
-            // Note: these do not edit the dependency map so there is no need to take a backup of it ourselves
-            branch = FindOrCreateInstruction(immAsAddr, parseState, "InstructionTree: recursing to branch location");
-            if (isCall()) {
-                parseState.functionCandidates.insert({immAsAddr, parseState.dependencyMap});  // the inserted depMap is a copy
-            }
-        } else {
-            log(ERROR, "Direct branch instruction had no immediate!");
+        CRASH_UNLESS(label);
+        const int32_t* addr = *label;
+        // Note: these do not edit the dependency map so there is no need to take a backup of it ourselves
+        branch = FindOrCreateInstruction(addr, parseState, "InstructionTree: recursing to branch location");
+        if (isCall()) {
+            parseState.functionCandidates.insert({addr, parseState.dependencyMap});  // the inserted depMap is a copy
         }
     }
     // unless instruction is unconditional branch, populate noBranch with next instruction in memory

--- a/shared/utils/instruction-parsing.cpp
+++ b/shared/utils/instruction-parsing.cpp
@@ -38,7 +38,7 @@ decltype(Instruction::result) ExtractAddress(Instruction* instWithResultAdr, Ins
     auto offset = *(instWithImmOffset->imm);
 
     auto jmp = jmpOff + offset;
-    log(DEBUG, "offset: %lX, jmp: %lX (offset %llX)", offset, jmp, jmp - getRealOffset(0));
+    log(DEBUG, "offset: %lX, jmp: %lX (offset %lX)", offset, jmp, jmp - getRealOffset(0));
     return jmp;
 }
 
@@ -1003,7 +1003,7 @@ Instruction::Instruction(const int32_t* inst) {
         valid = false;
     }
     if (parseLevel != sizeof(kind) / sizeof(kind[0])) {
-        log(WARNING, "Could not complete parsing of 0x%X (offset %llX) - need more handling for kind '%s'!", code, ((long long)addr) - getRealOffset(0), kind[parseLevel - 1]);
+        log(WARNING, "Could not complete parsing of 0x%X (offset %lX) - need more handling for kind '%s'!", code, ((intptr_t)addr) - getRealOffset(0), kind[parseLevel - 1]);
     } else {
         parsed = true;
         if (kind[parseLevel - 1] == unalloc) {
@@ -1021,10 +1021,10 @@ void InstructionTree::Eval(ProgramState* state) {
 InstructionTree* FindOrCreateInstruction(const int32_t* pc, ParseState& parseState, const char* msg) {
     auto p = parseState.codeToInstTree.find(pc);
     if (p != parseState.codeToInstTree.end()) {
-        log(DEBUG, "not recursing: InstructionTree for %p (offset %llX) already exists", pc, ((long long)pc) - getRealOffset(0));
+        log(DEBUG, "not recursing: InstructionTree for %p (offset %lX) already exists", pc, ((intptr_t)pc) - getRealOffset(0));
         return p->second;
     } else {
-        log(DEBUG, "%s (pc %p, offset %llX)", msg, pc, ((long long)pc) - getRealOffset(0));
+        log(DEBUG, "%s (pc %p, offset %lX)", msg, pc, ((intptr_t)pc) - getRealOffset(0));
         auto inst = new (std::nothrow) InstructionTree(pc);
         parseState.frontier.push({inst, parseState.dependencyMap});  // the inserted depMap is a copy
         parseState.codeToInstTree[pc] = inst;
@@ -1153,6 +1153,6 @@ AssemblyFunction::AssemblyFunction(const int32_t* pc): parseState() {
 
     log(INFO, "Function candidates: ");
     for (auto p : parseState.functionCandidates) {
-        log(INFO, "%p (offset %llX): depMap %s", p.first, ((long long)p.first) - getRealOffset(0), DepMapToString(p.second).c_str());
+        log(INFO, "%p (offset %lX): depMap %s", p.first, ((intptr_t)p.first) - getRealOffset(0), DepMapToString(p.second).c_str());
     }
 }

--- a/shared/utils/instruction-parsing.hpp
+++ b/shared/utils/instruction-parsing.hpp
@@ -27,13 +27,14 @@ public:
     const int32_t* addr;  // the pointer to the instruction
     // Rd and Rs are capitalized in accordance with typical Register notation
     int_fast8_t Rd = -2;  // the destination register's number, or -1 if none
-    int_fast8_t Rd2 = -2;  // the 2nd destination register's number, or -1 if none
+    int_fast8_t Rd2 = -1;  // the 2nd destination register's number, or -1 if none
     int_fast8_t numSourceRegisters = -1;  // the number of source registers this instruction has
     union {
         int_fast8_t Rs[3] = { -1, -1, -1 };  // the number(s) of the source register(s), e.g. {12, 29} for X12 & X29
         int64_t result;  // iff numSourceRegisters is 0, the value that will be stored to Rd by this instruction
     };
     std::optional<int64_t> imm;  // the immediate, if applicable
+    std::optional<const int32_t*> label;  // if present, a pointer to assembly to be calculated or jumped to
 
     // see https://developer.arm.com/docs/ddi0596/a/a64-shared-pseudocode-functions/aarch64-instrs-pseudocode#impl-aarch64.ShiftReg.3
     enum ShiftType {  // in most cases (exceptiing noShift) the amount is stored in imm and the shift is applied to Rm (Rs[1])

--- a/shared/utils/instruction-parsing.hpp
+++ b/shared/utils/instruction-parsing.hpp
@@ -121,7 +121,7 @@ public:
                 if (matches == n) return inst;
             } else if ((rets >= 0) && inst->isReturn()) {
                 if (rets == 0) {
-                    log(DEBUG, "Breaking on offset %llX", ((long long)inst->addr) - getRealOffset(0));
+                    log(DEBUG, "Breaking on offset %lX", ((intptr_t)inst->addr) - getRealOffset(0));
                     break;
                 }
                 rets--;

--- a/shared/utils/utils.h
+++ b/shared/utils/utils.h
@@ -81,6 +81,20 @@ auto crashUnless(T&& arg, const char* file, int line) {
 }
 #define CRASH_UNLESS(expr) crashUnless(expr, __FILE__, __LINE__)
 
+template<class T>
+intptr_t getBase(T pc) {
+    static_assert(sizeof(T) >= sizeof(void*));
+    Dl_info info;
+    RET_0_UNLESS(dladdr((void*)pc, &info));
+    return (intptr_t)info.dli_fbase;
+}
+
+template<class T>
+ptrdiff_t asOffset(T pc) {
+    auto base = getBase(pc);
+    return (ptrdiff_t)(((intptr_t)pc) - base);
+}
+
 extern "C" {
 #endif /* __cplusplus */
 

--- a/shared/utils/utils.h
+++ b/shared/utils/utils.h
@@ -112,16 +112,16 @@ void print(std::stringstream& ss, LOG_VERBOSE_TYPE lvl = INFO);
 //   It will not follow pointers that it has already analyzed as a result of the current call.
 void analyzeBytes(const void* ptr);
 
-long long getRealOffset(const void* offset);
-long long baseAddr(const char* soname);
+intptr_t getRealOffset(const void* offset);
+intptr_t baseAddr(const char* soname);
 
 // Only wildcard is ? and ?? - both are handled the same way. They will skip exactly 1 byte (2 hex digits)
-long long findPattern(long long dwAddress, const char* pattern, long long dwSearchRangeLen = 0x1000000);
+intptr_t findPattern(intptr_t dwAddress, const char* pattern, intptr_t dwSearchRangeLen = 0x1000000);
 // Same as findPattern but will continue scanning to make sure your pattern is sufficiently specific.
 // Each candidate will be logged. label should describe what you're looking for, like "Class::Init".
 // Sets "multiple" iff multiple matches are found, and outputs a log warning message.
 // Returns the first match, if any.
-long long findUniquePattern(bool& multiple, long long dwAddress, const char* pattern, const char* label = 0, long long dwSearchRangeLen = 0x1000000);
+intptr_t findUniquePattern(bool& multiple, intptr_t dwAddress, const char* pattern, const char* label = 0, intptr_t dwSearchRangeLen = 0x1000000);
 
 #define MAKE_HOOK(name, addr, retval, ...) \
 void* addr_ ## name = (void*) addr; \


### PR DESCRIPTION
Added [C/T]B(N)Z instruction parsing and the remaining Data Processing -- Immediate categories, 'Bitfield' and 'Extract'.