### PR TITLE
Fix for ref/out args!

### DIFF
--- a/shared/utils/il2cpp-functions.hpp
+++ b/shared/utils/il2cpp-functions.hpp
@@ -286,7 +286,7 @@ class il2cpp_functions {
     #ifdef UNITY_2019
     inline static bool (*type_is_static)(const Il2CppType * type);
     inline static bool (*type_is_pointer_type)(const Il2CppType * type);
-    #endif UNITY_2019
+    #endif
     inline static const Il2CppAssembly* (*image_get_assembly)(const Il2CppImage * image);
     inline static const char* (*image_get_name)(const Il2CppImage * image);
     inline static const char* (*image_get_filename)(const Il2CppImage * image);

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -61,6 +61,12 @@ namespace il2cpp_utils {
         return klass;
     }
 
+    // Seriously, don't un-const the returned Type
+    const Il2CppType* MakeRef(const Il2CppType* type);
+
+    // Generally, it's better to just use class_from_type!
+    const Il2CppType* UnRef(const Il2CppType* type);
+
     // Framework provided by DaNike
     namespace il2cpp_type_check {
         // To fix "no member named 'get' in il2cpp_type_check::il2cpp_arg_type_<Blah>", define il2cpp_arg_type_<Blah>!
@@ -69,7 +75,7 @@ namespace il2cpp_utils {
         struct il2cpp_arg_type_ {};
 
         template<typename T>
-        using il2cpp_arg_type = il2cpp_arg_type_<std::decay_t<T>>;
+        using il2cpp_arg_type = il2cpp_arg_type_<T>;
 
         #define DEFINE_IL2CPP_DEFAULT_TYPE(type, fieldName) \
         template<> \
@@ -162,6 +168,23 @@ namespace il2cpp_utils {
         };
         #undef has_obj
         #undef has_object
+
+        template<typename T>
+        struct il2cpp_arg_type_<T&> {
+            static inline Il2CppType const* get(T& arg) {
+                // A method can store a result back to a non-const ref! Make the type byref!
+                auto base = il2cpp_arg_type_<T>::get(arg);
+                return MakeRef(base);
+            }
+        };
+
+        template<typename T>
+        struct il2cpp_arg_type_<const T&> {
+            static inline Il2CppType const* get(const T& arg) {
+                // A method cannot store a result back to a const ref. It is not a C# ref.
+                return il2cpp_arg_type_<T>::get(arg);
+            }
+        };
 
         template<typename T>
         struct il2cpp_arg_ptr {


### PR DESCRIPTION
Any non-const, non-rvalue arg can now match ref/out C# parameters.
For example::

```
    // dumped C# method in public struct Int64:
    // public static bool TryParse(string s, out long result);

    // Works, prints "Parsed string as: 1234509876"
    auto intStr = il2cpp_utils::createcsstr("1234509876");
    int64_t out = 0;
    if (il2cpp_utils::RunMethod(il2cpp_functions::defaults->int64_class, "TryParse", intStr, out)) {
        log(DEBUG, "Parsed string as: %li", out);
    }

    // RunMethod will fail due to lack of match
    const int64_t fakeOut = 0;
    if (il2cpp_utils::RunMethod(il2cpp_functions::defaults->int64_class, "TryParse", intStr, fakeOut)) {
        log(DEBUG, "Parsed string as: %li", fakeOut);
    }
```

This enables you to safely call a non-ref overload using lvalues (variables) by simply making them const.