### PR TITLE
Property utils methods, dangerously untested

### DIFF
--- a/shared/utils/il2cpp-functions.cpp
+++ b/shared/utils/il2cpp-functions.cpp
@@ -626,6 +626,7 @@ void il2cpp_functions::Init() {
     il2cpp_functions::defaults = (decltype(il2cpp_functions::defaults))ExtractAddress(ldr->addr, 1, 1);
     log(DEBUG, "il2cpp_defaults found? offset: %lX", ((intptr_t)defaults) - getRealOffset(0));
     usleep(1000);  // 0.001s
+    CRASH_UNLESS(false);
 
     // FIELDS
     // Extract locations of s_GlobalMetadataHeader, s_Il2CppMetadataRegistration, & s_GlobalMetadata

--- a/shared/utils/il2cpp-functions.hpp
+++ b/shared/utils/il2cpp-functions.hpp
@@ -225,11 +225,11 @@ class il2cpp_functions {
     inline static void (*profiler_install_fileio)(Il2CppProfileFileIOFunc callback);
     inline static void (*profiler_install_thread)(Il2CppProfileThreadFunc start, Il2CppProfileThreadFunc end);
 
-    inline static uint32_t (*property_get_flags)(PropertyInfo * prop);
-    inline static const MethodInfo* (*property_get_get_method)(PropertyInfo * prop);
-    inline static const MethodInfo* (*property_get_set_method)(PropertyInfo * prop);
-    inline static const char* (*property_get_name)(PropertyInfo * prop);
-    inline static Il2CppClass* (*property_get_parent)(PropertyInfo * prop);
+    inline static uint32_t (*property_get_flags)(const PropertyInfo * prop);
+    inline static const MethodInfo* (*property_get_get_method)(const PropertyInfo * prop);
+    inline static const MethodInfo* (*property_get_set_method)(const PropertyInfo * prop);
+    inline static const char* (*property_get_name)(const PropertyInfo * prop);
+    inline static Il2CppClass* (*property_get_parent)(const PropertyInfo * prop);
     inline static Il2CppClass* (*object_get_class)(Il2CppObject * obj);
     inline static uint32_t (*object_get_size)(Il2CppObject * obj);
     inline static const MethodInfo* (*object_get_virtual_method)(Il2CppObject * obj, const MethodInfo * method);

--- a/shared/utils/il2cpp-utils.cpp
+++ b/shared/utils/il2cpp-utils.cpp
@@ -754,12 +754,12 @@ namespace il2cpp_utils {
         log(DEBUG, "element class: %p (self = %p)", element, klass);
         if (element && element != klass && logParents) LogClass(element, logParents);
 
-        log(DEBUG, "%i =========FIELDS=========", indent);
-        LogFields(klass);
-        log(DEBUG, "%i =======END FIELDS=======", indent);
         log(DEBUG, "%i =======PROPERTIES=======", indent);
         LogProperties(klass);
         log(DEBUG, "%i =====END PROPERTIES=====", indent);
+        log(DEBUG, "%i =========FIELDS=========", indent);
+        LogFields(klass);
+        log(DEBUG, "%i =======END FIELDS=======", indent);
 
         auto parent = il2cpp_functions::class_get_parent(klass);
         log(DEBUG, "parent: %p (%s)", parent, parent ? ClassStandardName(parent).c_str() : "");

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -271,6 +271,8 @@ namespace il2cpp_utils {
         if constexpr (sizeof...(TArgs) == 1 && (std::is_integral_v<std::decay_t<TArgs>> && ...)) {
             static_assert(false_t<TArgs...>,
                 "FindMethod using argCount is invalid! If argCount is 0 then remove it; otherwise use FindMethodUnsafe!");
+        } else if constexpr (sizeof...(TArgs) == 0) {
+            return FindMethodUnsafe(klass, methodName, 0);
         } else {
             return FindMethod(klass, methodName, {args...});
         }
@@ -278,8 +280,8 @@ namespace il2cpp_utils {
 
     // Returns the MethodInfo for the method on class found via namespace and name with the given other arguments
     template<class... TArgs>
-    const MethodInfo* FindMethod(std::string_view nameSpace, std::string_view className, TArgs&&... params) {
-        return FindMethod(GetClassFromName(nameSpace, className), params...);
+    const MethodInfo* FindMethod(std::string_view nameSpace, std::string_view className, std::string_view methodName, TArgs&&... params) {
+        return FindMethod(GetClassFromName(nameSpace, className), methodName, params...);
     }
     const MethodInfo* FindMethodUnsafe(std::string_view nameSpace, std::string_view className, std::string_view methodName, int argsCount);
 

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -641,12 +641,10 @@ namespace il2cpp_utils {
 
     // Gets an Il2CppObject* from the given class and property name
     // Returns nullptr if it fails
-    // Created by zoller27
     Il2CppObject* GetPropertyValue(Il2CppClass* klass, std::string_view propName);
 
     // Gets an Il2CppObject* from the given object instance and property name
     // Returns nullptr if it fails
-    // Created by darknight1050, modified by Sc2ad
     Il2CppObject* GetPropertyValue(Il2CppObject* instance, std::string_view propName);
 
     // Wrapper around the above GetPropertyValue's that casts the result for you
@@ -660,7 +658,6 @@ namespace il2cpp_utils {
     // Gets a value from the given object instance, and PropertyInfo, with return type TOut
     // Returns false if it fails
     // Assumes a static property if instance == nullptr
-    // Created by darknight1050, modified by Sc2ad and zoller27osu
     bool GetPropertyValue(TOut* out, T* instance, const PropertyInfo* prop) {
         il2cpp_functions::Init();
         RET_0_UNLESS(prop);
@@ -671,7 +668,6 @@ namespace il2cpp_utils {
     template<typename TOut>
     // Gets the value of the property with type TOut and the given name from the given class
     // Returns false if it fails
-    // Adapted by zoller27osu
     bool GetPropertyValue(TOut* out, Il2CppClass* klass, std::string_view propName) {
         il2cpp_functions::Init();
         RET_0_UNLESS(klass);
@@ -682,7 +678,6 @@ namespace il2cpp_utils {
     template<typename TOut>
     // Gets a value from the given object instance and property name, with return type TOut
     // Returns false if it fails
-    // Created by darknight1050, modified by Sc2ad and zoller27osu
     bool GetPropertyValue(TOut* out, Il2CppObject* instance, std::string_view propName) {
         il2cpp_functions::Init();
         RET_0_UNLESS(instance);
@@ -713,7 +708,6 @@ namespace il2cpp_utils {
     // Sets the value of a given property, given an object instance and property name
     // Unbox "value" before passing if it is an Il2CppObject but the property is a primitive or struct!
     // Returns false if it fails
-    // Adapted by zoller27osu
     bool SetPropertyValue(Il2CppClass* klass, std::string_view propName, void* value);
 
     // Sets the value of a given property, given an object instance and property name

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -280,8 +280,8 @@ namespace il2cpp_utils {
 
     // Returns the MethodInfo for the method on class found via namespace and name with the given other arguments
     template<class... TArgs>
-    const MethodInfo* FindMethod(std::string_view nameSpace, std::string_view className, std::string_view methodName, TArgs&&... params) {
-        return FindMethod(GetClassFromName(nameSpace, className), methodName, params...);
+    const MethodInfo* FindMethod(std::string_view nameSpace, std::string_view className, TArgs&&... params) {
+        return FindMethod(GetClassFromName(nameSpace, className), params...);
     }
     const MethodInfo* FindMethodUnsafe(std::string_view nameSpace, std::string_view className, std::string_view methodName, int argsCount);
 
@@ -336,7 +336,7 @@ namespace il2cpp_utils {
         // Note: we could also just call Runtime::Invoke directly, but box non-Il2CppObject instances ourselves as method->klass
         void* inst = instance;
         if constexpr (std::is_same_v<T, Il2CppObject>) {
-            if (method->klass->valuetype) {
+            if (instance && method->klass->valuetype) {
                 // We assume that if the method is for a ValueType and instance is an Il2CppObject, then it was pre-boxed.
                 inst = il2cpp_functions::object_unbox(instance);
             }
@@ -530,11 +530,10 @@ namespace il2cpp_utils {
     Il2CppObject* GetFieldValue(Il2CppObject* instance, std::string_view fieldName);
 
     // Wrapper around the non-template GetFieldValue's that casts the result for you
-    template<class TOut, class... TArgs>
-    TOut* GetFieldValue(TArgs... params) {
-        static_assert(sizeof...(TArgs) == 2);
-        static_assert(std::is_base_of_v<Il2CppObject, TOut>, "The return type of this function must inherit Il2CppObject! See GetFieldValueUnsafe for an alternative.");
-        return reinterpret_cast<TOut*>(GetFieldValue(params...));
+    template<class TOut, class TA, class TB>
+    std::enable_if_t<std::is_base_of_v<Il2CppObject, TOut>, TOut*>
+    GetFieldValue(TA* a, TB b) {
+        return reinterpret_cast<TOut*>(GetFieldValue(a, b));
     }
 
     template<typename TOut>
@@ -594,6 +593,7 @@ namespace il2cpp_utils {
         return out;
     }
 
+    // TODO: typecheck the SetField/PropertyValue methods' value params?
     // Sets the value of a given field, given an object instance and FieldInfo
     // Unbox "value" before passing if it is an Il2CppObject but the field is a primitive or struct!
     // Returns false if it fails
@@ -610,6 +610,116 @@ namespace il2cpp_utils {
     // Unbox "value" before passing if it is an Il2CppObject but the field is a primitive or struct!
     // Returns false if it fails
     bool SetFieldValue(Il2CppObject* instance, std::string_view fieldName, void* value);
+
+    // Returns the PropertyInfo for the property of the given class with the given name
+    // Created by zoller27osu
+    const PropertyInfo* FindProperty(Il2CppClass* klass, std::string_view propertyName);
+    // Wrapper for FindProperty taking a namespace and class name in place of an Il2CppClass*
+    template<class... TArgs>
+    const PropertyInfo* FindProperty(std::string_view nameSpace, std::string_view className, TArgs&&... params) {
+        return FindProperty(GetClassFromName(nameSpace, className), params...);
+    }
+    // Wrapper for FindProperty taking an Il2CppObject* in place of an Il2CppClass*
+    template<class... TArgs>
+    const PropertyInfo* FindProperty(Il2CppObject* instance, TArgs&&... params) {
+        return FindProperty(GetClassOfObject(instance, "FindProperty"), params...);
+    }
+
+    // Gets an Il2cppObject* from the given object instance and PropertyInfo
+    // instance can only be null for static properties
+    // Returns nullptr if it fails
+    template<class T>
+    Il2CppObject* GetPropertyValue(T* instance, const PropertyInfo* prop) {
+        il2cpp_functions::Init();
+        RET_0_UNLESS(prop);
+
+        auto getter = RET_0_UNLESS(il2cpp_functions::property_get_get_method(prop));
+        Il2CppObject* out = nullptr;
+        RET_0_UNLESS(RunMethod(out, instance, getter));
+        return out;
+    }
+
+    // Gets an Il2CppObject* from the given class and property name
+    // Returns nullptr if it fails
+    // Created by zoller27
+    Il2CppObject* GetPropertyValue(Il2CppClass* klass, std::string_view propName);
+
+    // Gets an Il2CppObject* from the given object instance and property name
+    // Returns nullptr if it fails
+    // Created by darknight1050, modified by Sc2ad
+    Il2CppObject* GetPropertyValue(Il2CppObject* instance, std::string_view propName);
+
+    // Wrapper around the above GetPropertyValue's that casts the result for you
+    template<class TOut, class TA, class TB>
+    std::enable_if_t<std::is_base_of_v<Il2CppObject, TOut>, TOut*>
+    GetPropertyValue(TA* a, TB b) {
+        return reinterpret_cast<TOut*>(GetPropertyValue(a, b));
+    }
+
+    template<class TOut, class T>
+    // Gets a value from the given object instance, and PropertyInfo, with return type TOut
+    // Returns false if it fails
+    // Assumes a static property if instance == nullptr
+    // Created by darknight1050, modified by Sc2ad and zoller27osu
+    bool GetPropertyValue(TOut* out, T* instance, const PropertyInfo* prop) {
+        il2cpp_functions::Init();
+        RET_0_UNLESS(prop);
+        auto getter = RET_0_UNLESS(il2cpp_functions::property_get_get_method(prop));
+        return RunMethod(out, instance, getter);
+    }
+
+    template<typename TOut>
+    // Gets the value of the property with type TOut and the given name from the given class
+    // Returns false if it fails
+    // Adapted by zoller27osu
+    bool GetPropertyValue(TOut* out, Il2CppClass* klass, std::string_view propName) {
+        il2cpp_functions::Init();
+        RET_0_UNLESS(klass);
+        auto prop = RET_0_UNLESS(FindProperty(klass, propName));
+        return GetPropertyValue<TOut, void>(out, nullptr, prop);
+    }
+
+    template<typename TOut>
+    // Gets a value from the given object instance and property name, with return type TOut
+    // Returns false if it fails
+    // Created by darknight1050, modified by Sc2ad and zoller27osu
+    bool GetPropertyValue(TOut* out, Il2CppObject* instance, std::string_view propName) {
+        il2cpp_functions::Init();
+        RET_0_UNLESS(instance);
+        auto prop = FindProperty(instance, propName);
+        return GetPropertyValue(out, instance, prop);
+    }
+
+    // An unsafe wrapper around the TOut GetPropertyValues; il2cpp should unbox when appropriate
+    template<class TOut, class... TArgs>
+    TOut GetPropertyValueUnsafe(TArgs... params) {
+        TOut out;
+        GetPropertyValue(&out, params...);
+        return out;
+    }
+
+    // Sets the value of a given property, given an object instance and PropertyInfo
+    // Unbox "value" before passing if it is an Il2CppObject but the property is a primitive or struct!
+    // Returns false if it fails
+    // Assumes static property if instance == nullptr
+    template<class T>
+    bool SetPropertyValue(T* instance, const PropertyInfo* prop, void* value) {
+        il2cpp_functions::Init();
+        RET_0_UNLESS(prop);
+        auto setter = RET_0_UNLESS(il2cpp_functions::property_get_set_method(prop));
+        return RunMethod(instance, setter, value);
+    }
+
+    // Sets the value of a given property, given an object instance and property name
+    // Unbox "value" before passing if it is an Il2CppObject but the property is a primitive or struct!
+    // Returns false if it fails
+    // Adapted by zoller27osu
+    bool SetPropertyValue(Il2CppClass* klass, std::string_view propName, void* value);
+
+    // Sets the value of a given property, given an object instance and property name
+    // Unbox "value" before passing if it is an Il2CppObject but the property is a primitive or struct!
+    // Returns false if it fails
+    bool SetPropertyValue(Il2CppObject* instance, std::string_view propName, void* value);
 
     template<typename T = MulticastDelegate, typename R, typename... TArgs>
     // Creates an Action and casts it to a MulticastDelegate*
@@ -671,6 +781,14 @@ namespace il2cpp_utils {
     // Created by zoller27osu
     // Calls LogField on all fields in the given class
     void LogFields(Il2CppClass* klass, bool logParents = false);
+
+    // Created by zoller27osu
+    // Logs information about the given PropertyInfo* as log(DEBUG)
+    void LogProperty(const PropertyInfo* field);
+
+    // Created by zoller27osu
+    // Calls LogProperty on all properties in the given class
+    void LogProperties(Il2CppClass* klass, bool logParents = false);
 
     // Some parts provided by zoller27osu
     // Logs information about the given Il2CppClass* as log(DEBUG)

--- a/shared/utils/utils.cpp
+++ b/shared/utils/utils.cpp
@@ -13,11 +13,11 @@
 
 using namespace std;
 
-void safeAbort(const char* file, int line) {
+void safeAbort(const char* func, const char* file, int line) {
     // we REALLY want this to appear at least once in the log (for fastest fixing)
     for (int i = 0; i < 2; i++) {
         usleep(100000L);  // 0.1s
-        log(CRITICAL, "Aborting at %s:%i", file, line);
+        log(CRITICAL, "Aborting in %s at %s:%i", func, file, line);
     }
     usleep(100000L);  // 0.1s
     std::terminate();  // cleans things up and then calls abort

--- a/shared/utils/utils.h
+++ b/shared/utils/utils.h
@@ -32,7 +32,7 @@ template <typename... Ts> struct is_vector<std::vector<Ts...> > : std::true_type
 #define RET_UNLESS(retval, expr) ({ \
     const auto& __temp__ = expr; \
     if (!__temp__) { \
-        log(ERROR, "%s (at %s:%i) returned false!", #expr, __FILE__, __LINE__); \
+        log(ERROR, "%s (in %s at %s:%i) returned false!", #expr, __func__, __FILE__, __LINE__); \
         return retval; \
     } \
     __temp__; \

--- a/shared/utils/utils.h
+++ b/shared/utils/utils.h
@@ -32,7 +32,7 @@ template <typename... Ts> struct is_vector<std::vector<Ts...> > : std::true_type
 #define RET_UNLESS(retval, expr) ({ \
     const auto& __temp__ = expr; \
     if (!__temp__) { \
-        log(ERROR, "%s (in %s at %s:%i) returned false!", #expr, __func__, __FILE__, __LINE__); \
+        log(ERROR, "%s (in %s at %s:%i) returned false!", #expr, __PRETTY_FUNCTION__, __FILE__, __LINE__); \
         return retval; \
     } \
     __temp__; \
@@ -72,14 +72,14 @@ static void StartCoroutine(Function&& fun, Args&&... args) {
 // logs the function, file and line, sleeps to allow logs to flush, then terminates program
 void safeAbort(const char* func, const char* file, int line);
 // sets "file" and "line" to the file and line you call this macro from
-#define SAFE_ABORT() safeAbort(__func__, __FILE__, __LINE__)
+#define SAFE_ABORT() safeAbort(__PRETTY_FUNCTION__, __FILE__, __LINE__)
 
 template<class T>
 auto crashUnless(T&& arg, const char* func, const char* file, int line) {
     if (!arg) safeAbort(func, file, line);
     return std::forward<T>(arg);
 }
-#define CRASH_UNLESS(expr) crashUnless(expr, __func__, __FILE__, __LINE__)
+#define CRASH_UNLESS(expr) crashUnless(expr, __PRETTY_FUNCTION__, __FILE__, __LINE__)
 
 template<class T>
 intptr_t getBase(T pc) {

--- a/shared/utils/utils.h
+++ b/shared/utils/utils.h
@@ -69,17 +69,17 @@ static void StartCoroutine(Function&& fun, Args&&... args) {
     t->detach();
 }
 
-// logs the file and line, sleeps to allow logs to flush, then terminates program
-void safeAbort(const char* file, int line);
+// logs the function, file and line, sleeps to allow logs to flush, then terminates program
+void safeAbort(const char* func, const char* file, int line);
 // sets "file" and "line" to the file and line you call this macro from
-#define SAFE_ABORT() safeAbort(__FILE__, __LINE__)
+#define SAFE_ABORT() safeAbort(__func__, __FILE__, __LINE__)
 
 template<class T>
-auto crashUnless(T&& arg, const char* file, int line) {
-    if (!arg) safeAbort(file, line);
+auto crashUnless(T&& arg, const char* func, const char* file, int line) {
+    if (!arg) safeAbort(func, file, line);
     return std::forward<T>(arg);
 }
-#define CRASH_UNLESS(expr) crashUnless(expr, __FILE__, __LINE__)
+#define CRASH_UNLESS(expr) crashUnless(expr, __func__, __FILE__, __LINE__)
 
 template<class T>
 intptr_t getBase(T pc) {


### PR DESCRIPTION
FindProperty, GetPropertyValue and SetPropertyValue need testing.

In my tests (which didn't call those) LogClasses called LogProperties just fine, so the loggers are working.