### PR TITLE
CreateParam/CreateFieldValue and matching MakeAction overloads.

### DIFF
--- a/shared/customui/customui.cpp
+++ b/shared/customui/customui.cpp
@@ -209,11 +209,10 @@ namespace CustomUI {
 
         // If only we could use UnityEngine.WWW and its WaitUntilDoneIfPossible() :(
         auto method = RET_0_UNLESS(FindMethodUnsafe("UnityEngine.Networking", "UnityWebRequestAsyncOperation", "add_completed", 1));
-        auto fieldType = il2cpp_functions::method_get_param(method, 0);
 
         RET_0_UNLESS(RunMethod(&sendWebRequestObj, WWW, "SendWebRequest"));
 
-        auto action = RET_0_UNLESS(MakeAction(this, textureWebRequestComplete, fieldType));
+        auto action = RET_0_UNLESS(MakeAction(method, 0, this, textureWebRequestComplete));
         RET_0_UNLESS(RunMethod(sendWebRequestObj, method, action));
 
         // Uncomment this to watch the progress for debugging purposes (backtracks a lot):

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -716,10 +716,10 @@ namespace il2cpp_utils {
     bool SetPropertyValue(Il2CppObject* instance, std::string_view propName, void* value);
 
     template<typename T = MulticastDelegate, typename R, typename... TArgs>
-    // Creates an Action and casts it to a MulticastDelegate*
-    // actionType should be extracted from the FieldInfo or MethodInfo you plan to send the action to!
+    // Creates an Action of type actionType, with the given callback and callback self 'obj', and casts it to a T*
+    // PLEASE!!! use the below FieldInfo or MethodInfo versions instead if you can.
     // Created by zoller27osu
-    T* MakeAction(Il2CppObject* obj, function_ptr_t<R, TArgs...> callback, const Il2CppType* actionType) {
+    T* MakeAction(const Il2CppType* actionType, Il2CppObject* obj, function_ptr_t<R, TArgs...> callback) {
         Il2CppClass* actionClass = il2cpp_functions::class_from_il2cpp_type(actionType);
 
         /*
@@ -747,9 +747,53 @@ namespace il2cpp_utils {
     }
 
     template<typename T = MulticastDelegate>
-    T* MakeAction(Il2CppObject* obj, void* callback, const Il2CppType* actionType) {
+    T* MakeAction(const Il2CppType* actionType, Il2CppObject* obj, void* callback) {
         auto tmp = reinterpret_cast<function_ptr_t<void>>(callback);
-        return MakeAction(obj, tmp, actionType);
+        return MakeAction(actionType, obj, tmp);
+    }
+
+    // Creates an Action fit to be passed in the given parameter position to the given method.
+    template<typename T = MulticastDelegate, typename... TArgs>
+    T* MakeAction(const MethodInfo* method, int paramIdx, TArgs&& ...args) {
+        auto actionType = RET_0_UNLESS(il2cpp_functions::method_get_param(method, paramIdx));
+        return MakeAction(actionType, args...);
+    }
+
+    // Creates an Action fit to be assigned to the given field.
+    template<typename T = MulticastDelegate, typename... TArgs>
+    T* MakeAction(FieldInfo* field, TArgs&& ...args) {
+        auto actionType = RET_0_UNLESS(il2cpp_functions::field_get_type(field));
+        return MakeAction(actionType, args...);
+    }
+
+    // Intializes an object with the given args fit to be passed to the given method at the given parameter index.
+    template<typename... TArgs>
+    Il2CppObject* CreateParam(const MethodInfo* method, int paramIdx, TArgs&& ...args) {
+        auto type = RET_0_UNLESS(il2cpp_functions::method_get_param(method, paramIdx));
+        auto klass = RET_0_UNLESS(il2cpp_functions::class_from_il2cpp_type(type));
+        return il2cpp_utils::New(klass, args...);
+    }
+
+    template<typename... TArgs>
+    Il2CppObject* CreateParamUnsafe(const MethodInfo* method, int paramIdx, TArgs&& ...args) {
+        auto type = RET_0_UNLESS(il2cpp_functions::method_get_param(method, paramIdx));
+        auto klass = RET_0_UNLESS(il2cpp_functions::class_from_il2cpp_type(type));
+        return il2cpp_utils::NewUnsafe(klass, args...);
+    }
+
+    // Intializes an object with the given args fit to be assigned to the given field.
+    template<typename... TArgs>
+    Il2CppObject* CreateFieldValue(FieldInfo* field, TArgs&& ...args) {
+        auto type = RET_0_UNLESS(il2cpp_functions::field_get_type(field));
+        auto klass = RET_0_UNLESS(il2cpp_functions::class_from_il2cpp_type(type));
+        return il2cpp_utils::New(klass, args...);
+    }
+
+    template<typename... TArgs>
+    Il2CppObject* CreateFieldValueUnsafe(FieldInfo* field, TArgs&& ...args) {
+        auto type = RET_0_UNLESS(il2cpp_functions::field_get_type(field));
+        auto klass = RET_0_UNLESS(il2cpp_functions::class_from_il2cpp_type(type));
+        return il2cpp_utils::NewUnsafe(klass, args...);
     }
 
     // Calls the System.RuntimeType.MakeGenericType(System.Type gt, System.Type[] types) function
@@ -757,8 +801,6 @@ namespace il2cpp_utils {
 
     // Function made by zoller27osu, modified by Sc2ad
     Il2CppClass* MakeGeneric(const Il2CppClass* klass, std::vector<const Il2CppClass*> args);
-
-
 
     // Function made by zoller27osu, modified by Sc2ad
     // Logs information about the given MethodInfo* as log(DEBUG)

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -766,7 +766,7 @@ namespace il2cpp_utils {
         return MakeAction(actionType, args...);
     }
 
-    // Intializes an object with the given args fit to be passed to the given method at the given parameter index.
+    // Intializes an object (using the given args) fit to be passed to the given method at the given parameter index.
     template<typename... TArgs>
     Il2CppObject* CreateParam(const MethodInfo* method, int paramIdx, TArgs&& ...args) {
         auto type = RET_0_UNLESS(il2cpp_functions::method_get_param(method, paramIdx));
@@ -781,7 +781,7 @@ namespace il2cpp_utils {
         return il2cpp_utils::NewUnsafe(klass, args...);
     }
 
-    // Intializes an object with the given args fit to be assigned to the given field.
+    // Intializes an object (using the given args) fit to be assigned to the given field.
     template<typename... TArgs>
     Il2CppObject* CreateFieldValue(FieldInfo* field, TArgs&& ...args) {
         auto type = RET_0_UNLESS(il2cpp_functions::field_get_type(field));
@@ -800,6 +800,7 @@ namespace il2cpp_utils {
     Il2CppReflectionType* MakeGenericType(Il2CppReflectionType* gt, Il2CppArray* types);
 
     // Function made by zoller27osu, modified by Sc2ad
+    // PLEASE don't use, there are easier ways to get generics (see CreateParam, CreateFieldValue)
     Il2CppClass* MakeGeneric(const Il2CppClass* klass, std::vector<const Il2CppClass*> args);
 
     // Function made by zoller27osu, modified by Sc2ad

--- a/shared/utils/instruction-parsing.cpp
+++ b/shared/utils/instruction-parsing.cpp
@@ -630,11 +630,11 @@ Instruction::Instruction(const int32_t* inst) {
                 if ((opc == 0b11) || (sf != N)) {
                     kind[parseLevel++] = unalloc;
                 } else if (opc == 0) {
-
+                    kind[parseLevel++] = sf ? "SBFM — 64-bit" : "SBFM — 32-bit";
                 } else if (opc == 0b1) {
-
+                    kind[parseLevel++] = sf ? "BFM — 64-bit" : "BFM — 32-bit";
                 } else if (opc == 0b10) {
-
+                    kind[parseLevel++] = sf ? "UBFM — 64-bit" : "UBFM — 32-bit";
                 }
                 log(DEBUG, "sf == N == %i, opc: %i", sf, opc);
             }

--- a/shared/utils/instruction-parsing.hpp
+++ b/shared/utils/instruction-parsing.hpp
@@ -240,7 +240,7 @@ private:
 
 // Truncates the given integer to its least significant N bits.
 template<class T>
-T trunc(T bits, size_t N) {
+T trunc(T bits, int N) {
     if (N == sizeof(T)*CHAR_BIT) return bits;
     CRASH_UNLESS(N < sizeof(T)*CHAR_BIT);
     return bits & ONES(N);
@@ -248,16 +248,16 @@ T trunc(T bits, size_t N) {
 
 // Transforms the given integer (with M denoting the true number of significant bits) into an unsigned number of type To.
 template<class To, class From>
-To ZeroExtend(From bits, size_t M) {
+To ZeroExtend(From bits, int M) {
     static_assert(std::is_unsigned_v<From>);
     return static_cast<To>(bits);
 }
 
 // Transforms the given integer (with M denoting the true number of significant bits) into a properly signed number of type To.
 template<class To, class From>
-To SignExtend(From bits, size_t M) {
+To SignExtend(From bits, int M) {
     static_assert(std::is_signed_v<To>);
-    constexpr uint8_t N = sizeof(To) * CHAR_BIT;
+    constexpr int N = sizeof(To) * CHAR_BIT;
     assert(N >= M);
     To prep = ((To)bits) << (N - M);
     return (prep >> (N - M));
@@ -265,7 +265,7 @@ To SignExtend(From bits, size_t M) {
 
 // Replicates the given bits (with M denoting the true number of significant bits) until they fill N bits.
 template<class To, class From>
-To Replicate(From bits, size_t M, size_t N) {
+To Replicate(From bits, int M, int N = sizeof(To) * CHAR_BIT) {
     CRASH_UNLESS(N % M == 0);
     To replicatedBits = bits;
     auto repSize = M;
@@ -282,15 +282,10 @@ To Replicate(From bits, size_t M, size_t N) {
     return replicatedBits;
 }
 
-template<class To, class From>
-To Replicate(From bits, size_t M) {
-    return Replicate<To>(bits, M, sizeof(To) * CHAR_BIT);
-}
-
 // N is the true number of significant bits in x.
 // Returns the index of the most significant ON bit in x.
 template<class T>
-int HighestSetBit(T x, size_t N) {
+int HighestSetBit(T x, int N) {
     for (int i = N - 1; i >= 0; i--) {
         if (x & (1 << i)) return i;
     }
@@ -300,26 +295,26 @@ int HighestSetBit(T x, size_t N) {
 // For all shifts (LSL, LSR, ASR, ROR): N is the true number of significant bits in x.
 // Left shift
 template<class T>
-T LSL(T x, size_t N, unsigned shift) {
+T LSL(T x, int N, unsigned shift) {
     return trunc(x << shift, N);
 }
 
 // Right shift, taking x as unsigned.
 template<class T>
-T LSR(T x, size_t N, unsigned shift) {
+T LSR(T x, int N, unsigned shift) {
     return trunc(x >> shift, N - shift);
 }
 
 // Right shift, taking x as signed.
 template<class T>
-T ASR(T x, size_t N, unsigned shift) {
+T ASR(T x, int N, unsigned shift) {
     typedef typename std::make_signed<T>::type signedT;
     return trunc(SignExtend<signedT>(x, N) >> shift, N);
 }
 
 // Right shift, but bits that "fall off" move to the front instead
 template<class T>
-T ROR(T x, size_t N, unsigned shift) {
+T ROR(T x, int N, unsigned shift) {
     shift %= N;
     T ret = LSR(x, N, shift) | LSL(x, N, N - shift);
     if ((ret == 0) && (x != 0)) {
@@ -332,7 +327,7 @@ T ROR(T x, size_t N, unsigned shift) {
 
 // Returns the value of the bits in x at index high through low inclusive, where the LSB is index 0 and the MSB's index >= high.
 template<class T>
-T bits(T x, size_t high, size_t low) {
+T bits(T x, int high, int low) {
     return trunc(x >> low, high - low + 1);
 }
 

--- a/shared/utils/instruction-parsing.hpp
+++ b/shared/utils/instruction-parsing.hpp
@@ -236,22 +236,26 @@ private:
     ParseState parseState;
 };
 
+#define ONES(N) ((1ull << (N)) - 1ull)
+
 // Truncates the given integer to its least significant N bits.
 template<class T>
-T trunc(T bits, uint8_t N) {
-    return bits & ((1ull << N) - 1ull);
+T trunc(T bits, size_t N) {
+    if (N == sizeof(T)*CHAR_BIT) return bits;
+    CRASH_UNLESS(N < sizeof(T)*CHAR_BIT);
+    return bits & ONES(N);
 }
 
 // Transforms the given integer (with M denoting the true number of significant bits) into an unsigned number of type To.
 template<class To, class From>
-To ZeroExtend(From bits, uint8_t M) {
+To ZeroExtend(From bits, size_t M) {
     static_assert(std::is_unsigned_v<From>);
     return static_cast<To>(bits);
 }
 
 // Transforms the given integer (with M denoting the true number of significant bits) into a properly signed number of type To.
 template<class To, class From>
-To SignExtend(From bits, uint8_t M) {
+To SignExtend(From bits, size_t M) {
     static_assert(std::is_signed_v<To>);
     constexpr uint8_t N = sizeof(To) * CHAR_BIT;
     assert(N >= M);
@@ -259,10 +263,34 @@ To SignExtend(From bits, uint8_t M) {
     return (prep >> (N - M));
 }
 
+// Replicates the given bits (with M denoting the true number of significant bits) until they fill N bits.
+template<class To, class From>
+To Replicate(From bits, size_t M, size_t N) {
+    CRASH_UNLESS(N % M == 0);
+    To replicatedBits = bits;
+    auto repSize = M;
+    while (repSize * 2 <= N) {
+        replicatedBits |= (replicatedBits << repSize);
+        repSize *= 2;
+    }
+    // The overlap should all match since N % M == 0 means that N - M*a % M == 0
+    replicatedBits |= (replicatedBits << (N - repSize));
+    if (N != M) {
+        log(DEBUG, "Replicate %s * %i = %s", std::bitset<sizeof(From)*CHAR_BIT>(bits).to_string().c_str(), N / M,
+            std::bitset<sizeof(To)*CHAR_BIT>(replicatedBits).to_string().c_str());
+    }
+    return replicatedBits;
+}
+
+template<class To, class From>
+To Replicate(From bits, size_t M) {
+    return Replicate<To>(bits, M, sizeof(To) * CHAR_BIT);
+}
+
 // N is the true number of significant bits in x.
 // Returns the index of the most significant ON bit in x.
 template<class T>
-int HighestSetBit(T x, uint8_t N) {
+int HighestSetBit(T x, size_t N) {
     for (int i = N - 1; i >= 0; i--) {
         if (x & (1 << i)) return i;
     }
@@ -272,33 +300,39 @@ int HighestSetBit(T x, uint8_t N) {
 // For all shifts (LSL, LSR, ASR, ROR): N is the true number of significant bits in x.
 // Left shift
 template<class T>
-T LSL(T x, uint8_t N, unsigned shift) {
+T LSL(T x, size_t N, unsigned shift) {
     return trunc(x << shift, N);
 }
 
 // Right shift, taking x as unsigned.
 template<class T>
-T LSR(T x, uint8_t N, unsigned shift) {
+T LSR(T x, size_t N, unsigned shift) {
     return trunc(x >> shift, N - shift);
 }
 
 // Right shift, taking x as signed.
 template<class T>
-T ASR(T x, uint8_t N, unsigned shift) {
+T ASR(T x, size_t N, unsigned shift) {
     typedef typename std::make_signed<T>::type signedT;
     return trunc(SignExtend<signedT>(x, N) >> shift, N);
 }
 
 // Right shift, but bits that "fall off" move to the front instead
 template<class T>
-T ROR(T x, uint8_t N, unsigned shift) {
+T ROR(T x, size_t N, unsigned shift) {
     shift %= N;
-    return LSR(x, N, shift) | LSL(x, N, N - shift);
+    T ret = LSR(x, N, shift) | LSL(x, N, N - shift);
+    if ((ret == 0) && (x != 0)) {
+        log(DEBUG, "%s ROR %i (-%i) returned %s!", std::bitset<sizeof(T)*CHAR_BIT>(x).to_string().c_str(), shift, N - shift,
+            std::bitset<sizeof(T)*CHAR_BIT>(ret).to_string().c_str());
+        SAFE_ABORT();
+    }
+    return ret;
 }
 
 // Returns the value of the bits in x at index high through low inclusive, where the LSB is index 0 and the MSB's index >= high.
 template<class T>
-T bits(T x, uint8_t high, uint8_t low) {
+T bits(T x, size_t high, size_t low) {
     return trunc(x >> low, high - low + 1);
 }
 


### PR DESCRIPTION
Also added Bitfield instruction parsing. This was the final class of unknown instructions encountered by `AssemblyFunction((const int32_t*)il2cpp_functions::type_get_assembly_qualified_name);` It now runs without warnings.

TODO: mark MakeGeneric deprecated?