### PR TITLE
std::optional overhaul

### DIFF
--- a/shared/customui/customui.cpp
+++ b/shared/customui/customui.cpp
@@ -30,10 +30,9 @@ namespace CustomUI {
         log(DEBUG, "TextObject::create: Getting type of TMPro.TMP_FontAsset");
         Il2CppObject *type_fontasset = GetSystemType("TMPro", "TMP_FontAsset");
         log(DEBUG, "TextObject::create: Gotten the type!");
-        Array<Il2CppObject *> *allObjects;
 
         // Find Objects of type TMP_fontAsset
-        allObjects = *RET_0_UNLESS(RunMethod<decltype(allObjects)>("UnityEngine", "Resources", "FindObjectsOfTypeAll", type_fontasset));
+        auto* allObjects = *RET_0_UNLESS(RunMethod<Array<Il2CppObject*>*>("UnityEngine", "Resources", "FindObjectsOfTypeAll", type_fontasset));
         int match = -1;
         for (int i = 0; i < allObjects->Length(); i++) {
             // Treat it as a UnityEngine.Object (which it is) and call the name getter
@@ -122,8 +121,8 @@ namespace CustomUI {
         std::vector<decltype(Array<int>::max_length)> recvLens;
         while (!isDone) {
             isDone = il2cpp_utils::RunMethod<bool>(obj->WWW, "get_isDone").value_or(false);
-            auto prog = il2cpp_utils::RunMethod<float>(obj->WWW, "GetDownloadProgress").value_or(-1);
-            if (prog >= 0) {
+            if (auto progOpt = il2cpp_utils::RunMethod<float>(obj->WWW, "GetDownloadProgress")) {
+                float prog = *progOpt;
                 if (prog != prevProg) {
                     auto dataLen = findDataSize(downloadHandler);
                     decltype(Array<int>::max_length) cap = std::round(((float)dataLen) / prog);

--- a/shared/customui/customui.cpp
+++ b/shared/customui/customui.cpp
@@ -24,7 +24,7 @@ namespace CustomUI {
         Il2CppObject *type_tmpugui = GetSystemType("TMPro", "TextMeshProUGUI");
 
         log(DEBUG, "TextObject::create: Adding component TMPro.TextMeshProUGUI");
-        RET_0_UNLESS(RunMethod(&textMesh, gameObj, "AddComponent", type_tmpugui));
+        textMesh = *RET_0_UNLESS(RunMethod(gameObj, "AddComponent", type_tmpugui));
 
         // textMesh.font = GameObject.Instantiate(Resources.FindObjectsOfTypeAll<TMP_FontAsset>().First(t => t.name == "Teko-Medium SDF No Glow"));
         log(DEBUG, "TextObject::create: Getting type of TMPro.TMP_FontAsset");
@@ -33,12 +33,11 @@ namespace CustomUI {
         Array<Il2CppObject *> *allObjects;
 
         // Find Objects of type TMP_fontAsset
-        RET_0_UNLESS(RunMethod(&allObjects, "UnityEngine", "Resources", "FindObjectsOfTypeAll", type_fontasset));
+        allObjects = *RET_0_UNLESS(RunMethod<decltype(allObjects)>("UnityEngine", "Resources", "FindObjectsOfTypeAll", type_fontasset));
         int match = -1;
         for (int i = 0; i < allObjects->Length(); i++) {
             // Treat it as a UnityEngine.Object (which it is) and call the name getter
-            Il2CppString *assetName;
-            RET_0_UNLESS(RunMethod(&assetName, allObjects->values[i], "get_name"));
+            auto* assetName = *RET_0_UNLESS(RunMethod<Il2CppString*>(allObjects->values[i], "get_name"));
             if (to_utf8(csstrtostr(assetName)) == "Teko-Medium SDF No Glow") {
                 // Found matching asset
                 match = i;
@@ -48,16 +47,14 @@ namespace CustomUI {
         RET_0_UNLESS(match != -1);
 
         log(DEBUG, "TextObject::create: Instantiating the font");
-        Il2CppObject *font;
-        RET_0_UNLESS(RunMethod(&font, "UnityEngine", "Object", "Instantiate", allObjects->values[match]));
+        auto* font = *RET_0_UNLESS(RunMethod("UnityEngine", "Object", "Instantiate", allObjects->values[match]));
 
         log(DEBUG, "TextObject::create: Setting the font");
         RET_0_UNLESS(RunMethod(textMesh, "set_font", font));
 
         // textMesh.rectTransform.SetParent(parent, false);
         log(DEBUG, "TextObject::create: Getting rectTransform");
-        Il2CppObject *rectTransform;
-        RET_0_UNLESS(RunMethod(&rectTransform, textMesh, "get_rectTransform"));
+        auto* rectTransform = *RET_0_UNLESS(RunMethod(textMesh, "get_rectTransform"));
 
         log(DEBUG, "TextObject::create: Setting Parent");
         if (!parentTransform) {
@@ -103,22 +100,20 @@ namespace CustomUI {
     }
 
     bool TextObject::set(std::string_view text) {
-        auto str = il2cpp_utils::createcsstr(text);
+        auto* str = il2cpp_utils::createcsstr(text);
         RET_0_UNLESS(il2cpp_utils::SetPropertyValue(textMesh, "text", str));
         return true;
     }
 
     static auto findDataSize(Il2CppObject* downloadHandler) {
-        Array<uint8_t>* data;
-        if (il2cpp_utils::RunMethod(&data, "UnityEngine.Networking", "DownloadHandler", "InternalGetByteArray", downloadHandler)) {
-            return data->Length();
-        }
-        return 0;
+        auto* data = *RET_0_UNLESS(il2cpp_utils::RunMethod<Array<uint8_t>*>(
+            "UnityEngine.Networking", "DownloadHandler", "InternalGetByteArray", downloadHandler));
+        return data->Length();
     }
 
     void RawImageObject::monitorProgress(RawImageObject* obj) {
         log(INFO, "monitorProgress start");
-        Il2CppObject* downloadHandler = il2cpp_utils::GetFieldValue(obj->WWW, "m_DownloadHandler");
+        Il2CppObject* downloadHandler = *RET_V_UNLESS(il2cpp_utils::GetFieldValue(obj->WWW, "m_DownloadHandler"));
         if (!downloadHandler) return;
 
         bool isDone = false;
@@ -126,9 +121,9 @@ namespace CustomUI {
         float prevProg = -1;
         std::vector<decltype(Array<int>::max_length)> recvLens;
         while (!isDone) {
-            il2cpp_utils::RunMethod(&isDone, obj->WWW, "get_isDone");
-            float prog;
-            if (il2cpp_utils::RunMethod(&prog, obj->WWW, "GetDownloadProgress")) {
+            isDone = il2cpp_utils::RunMethod<bool>(obj->WWW, "get_isDone").value_or(false);
+            auto prog = il2cpp_utils::RunMethod<float>(obj->WWW, "GetDownloadProgress").value_or(-1);
+            if (prog >= 0) {
                 if (prog != prevProg) {
                     auto dataLen = findDataSize(downloadHandler);
                     decltype(Array<int>::max_length) cap = std::round(((float)dataLen) / prog);
@@ -154,13 +149,11 @@ namespace CustomUI {
         log(INFO, "real progs (out of %i): %s", finalLen, ss.str().c_str());
 
         log(INFO, "webRequest isDone.");
-        Il2CppString* str;
-        if (RunMethod(&str, obj->WWW, "get_error")) {
-            if (str) {
-                log(ERROR, "webRequest error: %s", to_utf8(csstrtostr(str)).c_str());
-            } else {
-                log(DEBUG, "webRequest had no error.");
-            }
+        auto* str = *RET_V_UNLESS(RunMethod<Il2CppString*>(obj->WWW, "get_error"));
+        if (str) {
+            log(ERROR, "webRequest error: %s", to_utf8(csstrtostr(str)).c_str());
+        } else {
+            log(DEBUG, "webRequest had no error.");
         }
     }
 
@@ -168,15 +161,14 @@ namespace CustomUI {
         // Notes: The field named "<webRequest>k__BackingField" on asyncOp is a pointer that should match obj->WWW
         log(DEBUG, "Entering textureWebRequestComplete!");
 
-        RET_0_UNLESS(RunMethod(&obj->recievedTexture2D, "UnityEngine.Networking", "DownloadHandlerTexture", "GetContent", obj->WWW));
+        obj->recievedTexture2D = *RET_0_UNLESS(RunMethod("UnityEngine.Networking", "DownloadHandlerTexture", "GetContent", obj->WWW));
 
-        obj->gameObj = New(GetClassFromName("UnityEngine", "GameObject"), createcsstr("RandomImage"));
+        obj->gameObj = RET_0_UNLESS(New(GetClassFromName("UnityEngine", "GameObject"), createcsstr("RandomImage")));
         RET_0_UNLESS(RunMethod(obj->gameObj, "SetActive", false));
-        RET_0_UNLESS(RunMethod(&obj->rawImage, obj->gameObj, "AddComponent", GetSystemType("UnityEngine.UI", "RawImage")));
+        obj->rawImage = *RET_0_UNLESS(RunMethod(obj->gameObj, "AddComponent", GetSystemType("UnityEngine.UI", "RawImage")));
         RET_0_UNLESS(RunMethod(obj->rawImage, "set_texture", obj->recievedTexture2D));
 
-        Il2CppObject *rawImageRectTransform;
-        RET_0_UNLESS(RunMethod(&rawImageRectTransform, obj->rawImage, "get_rectTransform"));
+        auto* rawImageRectTransform = *RET_0_UNLESS(RunMethod(obj->rawImage, "get_rectTransform"));
         if (!obj->parentTransform) {
             log(ERROR, "RawImageObject::textureWebRequestComplete: obj->parentTransform is null! Fix it!");
         }
@@ -205,14 +197,14 @@ namespace CustomUI {
     }
 
     bool RawImageObject::create() {
-        RET_0_UNLESS(RunMethod(&WWW, "UnityEngine.Networking", "UnityWebRequestTexture", "GetTexture", createcsstr(url)));
+        WWW = *RET_0_UNLESS(RunMethod("UnityEngine.Networking", "UnityWebRequestTexture", "GetTexture", createcsstr(url)));
 
         // If only we could use UnityEngine.WWW and its WaitUntilDoneIfPossible() :(
-        auto method = RET_0_UNLESS(FindMethodUnsafe("UnityEngine.Networking", "UnityWebRequestAsyncOperation", "add_completed", 1));
+        auto* method = RET_0_UNLESS(FindMethodUnsafe("UnityEngine.Networking", "UnityWebRequestAsyncOperation", "add_completed", 1));
 
-        RET_0_UNLESS(RunMethod(&sendWebRequestObj, WWW, "SendWebRequest"));
+        sendWebRequestObj = *RET_0_UNLESS(RunMethod(WWW, "SendWebRequest"));
 
-        auto action = RET_0_UNLESS(MakeAction(method, 0, this, textureWebRequestComplete));
+        auto* action = RET_0_UNLESS(MakeAction(method, 0, this, textureWebRequestComplete));
         RET_0_UNLESS(RunMethod(sendWebRequestObj, method, action));
 
         // Uncomment this to watch the progress for debugging purposes (backtracks a lot):

--- a/shared/utils/il2cpp-utils.cpp
+++ b/shared/utils/il2cpp-utils.cpp
@@ -226,7 +226,8 @@ namespace il2cpp_utils {
     }
 
     const MethodInfo* FindMethodUnsafe(Il2CppObject* instance, std::string_view methodName, int argsCount) {
-        return FindMethodUnsafe(GetClassOfObject(instance, "FindMethod"), methodName, argsCount);
+        auto klass = RET_0_UNLESS(il2cpp_functions::object_get_class(instance));
+        return FindMethodUnsafe(klass, methodName, argsCount);
     }
 
     const MethodInfo* FindMethod(Il2CppClass* klass, std::string_view methodName, std::vector<const Il2CppType*> argTypes) {
@@ -305,29 +306,6 @@ namespace il2cpp_utils {
         return field;
     }
 
-    Il2CppObject* GetFieldValue(Il2CppObject* instance, FieldInfo* field) {
-        il2cpp_functions::Init();
-        RET_0_UNLESS(field);
-
-        return il2cpp_functions::field_get_value_object(field, instance);
-    }
-
-    Il2CppObject* GetFieldValue(Il2CppClass* klass, std::string_view fieldName) {
-        il2cpp_functions::Init();
-        RET_0_UNLESS(klass);
-
-        auto field = RET_0_UNLESS(FindField(klass, fieldName));
-        return GetFieldValue(nullptr, field);
-    }
-
-    Il2CppObject* GetFieldValue(Il2CppObject* instance, std::string_view fieldName) {
-        il2cpp_functions::Init();
-        RET_0_UNLESS(instance);
-
-        auto field = RET_0_UNLESS(FindField(instance, fieldName));
-        return GetFieldValue(instance, field);
-    }
-
     bool SetFieldValue(Il2CppObject* instance, FieldInfo* field, void* value) {
         il2cpp_functions::Init();
         RET_0_UNLESS(field);
@@ -374,22 +352,6 @@ namespace il2cpp_utils {
         }
         classesNamesToPropertiesCache.insert({key, prop});
         return prop;
-    }
-
-    Il2CppObject* GetPropertyValue(Il2CppClass* klass, std::string_view propName) {
-        il2cpp_functions::Init();
-        RET_0_UNLESS(klass);
-
-        auto prop = RET_0_UNLESS(FindProperty(klass, propName));
-        return GetPropertyValue<void>(nullptr, prop);
-    }
-
-    Il2CppObject* GetPropertyValue(Il2CppObject* instance, std::string_view propName) {
-        il2cpp_functions::Init();
-        RET_0_UNLESS(instance);
-
-        auto prop = RET_0_UNLESS(FindProperty(instance, propName));
-        return GetPropertyValue(instance, prop);
     }
 
     bool SetPropertyValue(Il2CppClass* klass, std::string_view propName, void* value) {

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -312,10 +312,8 @@ namespace il2cpp_utils {
     }
 
     template<class TOut = Il2CppObject*, class T, class... TArgs>
-    // Runs a MethodInfo with the specified parameters and instance, with return type TOut
-    // Assumes a static method if instance == nullptr
-    // Returns false if it fails
-    // Created by zoller27osu, modified by Sc2ad
+    // Runs a MethodInfo with the specified parameters and instance, with return type TOut.
+    // Assumes a static method if instance == nullptr. May fail due to exception or wrong name, hence the std::optional.
     std::optional<TOut> RunMethod(T* instance, const MethodInfo* method, TArgs&& ...params) {
         il2cpp_functions::Init();
         RET_NULLOPT_UNLESS(method);
@@ -350,9 +348,8 @@ namespace il2cpp_utils {
 
     template<class TOut = Il2CppObject*, class T, class... TArgs>
     // Runs a (static) method with the specified method name, with return type TOut.
-    // Checks the types of the parameters against the candidate methods. Returns false if it fails.
-    // Created by zoller27osu, modified by Sc2ad
-    // TODO: define these via KlassOrInstance types if possible
+    // Checks the types of the parameters against the candidate methods.
+    // TODO: define classOrInstance T's via a ClassOrInstance type if possible
     std::enable_if_t<std::is_base_of_v<Il2CppClass, T> || std::is_base_of_v<Il2CppObject, T>, std::optional<TOut>>
     RunMethod(T* classOrInstance, std::string_view methodName, TArgs&& ...params) {
         il2cpp_functions::Init();
@@ -373,8 +370,7 @@ namespace il2cpp_utils {
 
     template<class TOut = Il2CppObject*, class T, class... TArgs>
     // Runs a (static) method with the specified method name and number of arguments, with return type TOut.
-    // DOES NOT PERFORM TYPE CHECKING. Returns false if it fails.
-    // Created by zoller27osu, modified by Sc2ad
+    // DOES NOT PERFORM TYPE CHECKING.
     std::enable_if_t<std::is_base_of_v<Il2CppClass, T> || std::is_base_of_v<Il2CppObject, T>, std::optional<TOut>>
     RunMethodUnsafe(T* classOrInstance, std::string_view methodName, TArgs&& ...params) {
         il2cpp_functions::Init();
@@ -390,7 +386,6 @@ namespace il2cpp_utils {
     template<class TOut = Il2CppObject*, class... TArgs>
     // Runs a static method with the specified method name and arguments, on the class with the specified namespace and class name.
     // The method also has return type TOut.
-    // DOES NOT PERFORM TYPE CHECKING. Returns false if it fails.
     std::optional<TOut> RunMethod(std::string_view nameSpace, std::string_view klassName, std::string_view methodName, TArgs&& ...params) {
         auto klass = RET_NULLOPT_UNLESS(GetClassFromName(nameSpace, klassName));
         return RunMethod<TOut>(klass, methodName, params...);
@@ -399,7 +394,7 @@ namespace il2cpp_utils {
     template<class TOut = Il2CppObject*, class... TArgs>
     // Runs a static method with the specified method name and arguments, on the class with the specified namespace and class name.
     // The method also has return type TOut.
-    // DOES NOT PERFORM TYPE CHECKING. Returns false if it fails.
+    // DOES NOT PERFORM TYPE CHECKING.
     std::optional<TOut> RunMethodUnsafe(std::string_view nameSpace, std::string_view klassName, std::string_view methodName, TArgs&& ...params) {
         auto klass = RET_NULLOPT_UNLESS(GetClassFromName(nameSpace, klassName));
         return RunMethodUnsafe<TOut>(klass, methodName, params...);
@@ -485,7 +480,8 @@ namespace il2cpp_utils {
         return GetFieldValue<TOut>(instance, field);
     }
 
-    // TODO: typecheck the SetField/PropertyValue methods' value params?
+    // TODO: typecheck the Set[Field/Property]Value methods' value params?
+
     // Sets the value of a given field, given an object instance and FieldInfo
     // Unbox "value" before passing if it is an Il2CppObject but the field is a primitive or struct!
     // Returns false if it fails
@@ -519,7 +515,7 @@ namespace il2cpp_utils {
     }
 
     template<class TOut = Il2CppObject*, class T>
-    // Gets a value from the given object instance, and PropertyInfo, with return type TOut
+    // Gets a value from the given object instance, and PropertyInfo, with return type TOut.
     // Assumes a static property if instance == nullptr
     std::optional<TOut> GetPropertyValue(T* instance, const PropertyInfo* prop) {
         il2cpp_functions::Init();
@@ -529,8 +525,7 @@ namespace il2cpp_utils {
     }
 
     template<typename TOut = Il2CppObject*>
-    // Gets the value of the property with type TOut and the given name from the given class
-    // Returns false if it fails
+    // Gets the value of the property with the given name from the given class, and returns it as TOut.
     std::optional<TOut> GetPropertyValue(Il2CppClass* klass, std::string_view propName) {
         il2cpp_functions::Init();
         RET_NULLOPT_UNLESS(klass);
@@ -539,8 +534,7 @@ namespace il2cpp_utils {
     }
 
     template<typename TOut = Il2CppObject*>
-    // Gets a value from the given object instance and property name, with return type TOut
-    // Returns false if it fails
+    // Gets a value from the given object instance and property name, and returns it as TOut.
     std::optional<TOut> GetPropertyValue(Il2CppObject* instance, std::string_view propName) {
         il2cpp_functions::Init();
         RET_NULLOPT_UNLESS(instance);

--- a/shared/utils/utils.h
+++ b/shared/utils/utils.h
@@ -39,6 +39,7 @@ template <typename... Ts> struct is_vector<std::vector<Ts...> > : std::true_type
 })
 #define RET_V_UNLESS(expr) RET_UNLESS(, expr)
 #define RET_0_UNLESS(expr) RET_UNLESS(0, expr)
+#define RET_NULLOPT_UNLESS(expr) RET_UNLESS(std::nullopt, expr)
 
 // Produces a has_[member]<T, U> type trait whose ::value tells you whether T has a member named [member] with type U.
 #define DEFINE_MEMBER_CHECKER(member) \


### PR DESCRIPTION
All `RunMethod`, `GetFieldValue`, `GetPropertyValue`, and variants thereof now return `std::optional<TOut>` instead of (returning `bool` + taking `TOut*` as a parameter).

`std::optional` values are usable in `if` conditions, castable to `bool` and possess a `bool has_value()` method. These all do the same thing: in our case, if the optional evaluates to false, then the RunMethod failed.

Otherwise, `std::optional<T> opt` also acts like a pointer to `T`. This means that `*opt` gets the value that the optional contains (in our case, the return value of the RunMethod call), and `opt->blah()` calls `.blah()` on the contained `T`. Both of these have UNDEFINED BEHAVIOR IF THE OPTIONAL IS EMPTY. Always check the boolean part first!

Tips for working with the optional versions:
1. `*[CRASH/RET_0]_UNLESS(RunMethod...` is a good, safe way to get the optional's contents, but they may print errors.
1b.
```
if (auto opt = RunMethod...) {
    actualReturnValue = *opt;
```
works silently.
2. If the type you want isn't an Il2CppObject*, you must explicitly specify the RunMethod return type like so: `RunMethod<Il2CppString*>(...`; `RunMethod<float>(...`
3. If the return type should be a pointer, capture it with `auto* blah = [tip 1]` - this helps to ensure that you don't forget to unwrap the optional. Otherwise the safest bet is to use the actual type.