### PR TITLE
Fixes UNINSTALL_HOOK (still bad, see details)

### DIFF
--- a/shared/utils/instruction-parsing.cpp
+++ b/shared/utils/instruction-parsing.cpp
@@ -200,8 +200,8 @@ Instruction::Instruction(const int32_t* inst) {
     auto code = *inst;
     // https://developer.arm.com/docs/ddi0596/a/top-level-encodings-for-a64#top
     uint_fast8_t top0 = bits(code, 28, 25);  // op0 for top-level only
-    log(DEBUG, "inst: ptr = 0x%lX (offset 0x%lX), bytes = %s, top-level op0: %i",
-        pc, pc - base, std::bitset<32>(code).to_string().c_str(), top0);
+    log(DEBUG, "inst: ptr = 0x%lX (offset 0x%lX), bytes = %s (%X), top-level op0: %i",
+        pc, pc - base, std::bitset<32>(code).to_string().c_str(), code, top0);
     // Bit patterns like 1x0x where x is any bit and all other bits must match are implemented by:
     // 1. (a & [1's where pattern has non-x]) == [pattern with x's as 0]
     // 2. (a | [1's where pattern has x])     == [pattern with x's as 1]
@@ -1092,7 +1092,7 @@ Instruction::Instruction(const int32_t* inst) {
         SAFE_ABORT();
     }
     if (parseLevel < sizeof(kind) / sizeof(kind[0])) {
-        log(WARNING, "Could not complete parsing of 0x%X (offset %lX) - need more handling for kind '%s'!", code, pc - base, kind[parseLevel - 1]);
+        log(WARNING, "Could not complete parsing of 0x%lX (offset %lX) - need more handling for kind '%s'!", pc, pc - base, kind[parseLevel - 1]);
     } else {
         parsed = true;
         if (kind[parseLevel - 1] == unalloc) {

--- a/shared/utils/utils.h
+++ b/shared/utils/utils.h
@@ -218,22 +218,22 @@ A64HookFunction((void*)addr, (void*) hook_ ## name, (void**)&name); \
 
 #define UNINSTALL_HOOK(name) MACRO_WRAP( \
 log(INFO, "Uninstalling 64 bit hook: %s", #name); \
-A64HookFunction((void*)getRealOffset(addr_ ## name),(void*)&name, (void**)nullptr); \
+A64HookFunction((void*)getRealOffset(addr_ ## name),(void*)name, (void**)nullptr); \
 )
 
 #define UNINSTALL_HOOK_OFFSETLESS(name, methodInfo) MACRO_WRAP( \
 log(INFO, "Uninstalling 64 bit offsetless hook: %s", #name); \
-A64HookFunction((void*)methodInfo->methodPointer,(void*)&name, (void**)nullptr); \
+A64HookFunction((void*)methodInfo->methodPointer,(void*)name, (void**)nullptr); \
 )
 
 #define UNINSTALL_HOOK_NAT(name) MACRO_WRAP( \
 log(INFO, "Uninstalling 64 bit native hook: %s", #name); \
-A64HookFunction((void*)(addr_ ## name),(void*)&name, (void**)nullptr); \
+A64HookFunction((void*)(addr_ ## name),(void*)name, (void**)nullptr); \
 )
 
 #define UNINSTALL_HOOK_DIRECT(name, addr) MACRO_WRAP( \
 log(INFO, "Uninstalling 64 bit direct hook: %s", #name); \
-A64HookFunction((void*)addr, (void*)&name, (void**)nullptr); \
+A64HookFunction((void*)addr, (void*)name, (void**)nullptr); \
 )
 
 #else
@@ -289,19 +289,19 @@ A64HookFunction((void*)addr, (void*) hook_ ## name, (void**)&name); \
 // No original trampoline is created when uninstalling a hook, hence the nullptr
 
 #define UNINSTALL_HOOK(name) MACRO_WRAP( \
-A64HookFunction((void*)getRealOffset(addr_ ## name),(void*)&name, (void**)nullptr); \
+A64HookFunction((void*)getRealOffset(addr_ ## name),(void*)name, (void**)nullptr); \
 )
 
 #define UNINSTALL_HOOK_OFFSETLESS(name, methodInfo) MACRO_WRAP( \
-A64HookFunction((void*)methodInfo->methodPointer,(void*)&name, (void**)nullptr); \
+A64HookFunction((void*)methodInfo->methodPointer,(void*)name, (void**)nullptr); \
 )
 
 #define UNINSTALL_HOOK_NAT(name) MACRO_WRAP( \
-A64HookFunction((void*)(addr_ ## name),(void*)&name, (void**)nullptr); \
+A64HookFunction((void*)(addr_ ## name),(void*)name, (void**)nullptr); \
 )
 
 #define UNINSTALL_HOOK_DIRECT(name, addr) MACRO_WRAP( \
-A64HookFunction((void*)addr, (void*)&name, (void**)nullptr); \
+A64HookFunction((void*)addr, (void*)name, (void**)nullptr); \
 )
 
 #else __aarch64__


### PR DESCRIPTION
Summary of Sc2ad's commentary:
UNINSTALL_HOOK currently leaves the created trampoline in place, and simply redirects it to the original. Hence, using INSTALL_HOOK on the same target even after UNINSTALL will still add another layer of indirection, and thus increase memory usage and decrease performance. 

Therefore, UNINSTALL_HOOK should only be used once or not at all per hook target - it's far better for performance to disable hook behaviour some other way but leave the hook installed, rather than repeatedly installing and uninstalling it.

Also, better printing in instruction-parsing.