### PR TITLE
GetField can now return actual Il2CppObject* when asked to

### DIFF
--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -469,10 +469,14 @@ namespace il2cpp_utils {
         RET_NULLOPT_UNLESS(field);
 
         TOut out;
-        if (instance) {
-            il2cpp_functions::field_get_value(instance, field, &out);
-        } else { // Fallback to perform a static field set
-            il2cpp_functions::field_static_get_value(field, &out);
+        if constexpr (std::is_convertible_v<TOut, Il2CppObject*>) {
+            out = static_cast<TOut>(il2cpp_functions::field_get_value_object(field, instance));
+        } else {
+            if (instance) {
+                il2cpp_functions::field_get_value(instance, field, &out);
+            } else { // Fallback to perform a static field set
+                il2cpp_functions::field_static_get_value(field, &out);
+            }
         }
         return out;
     }

--- a/shared/utils/utils.h
+++ b/shared/utils/utils.h
@@ -198,7 +198,7 @@ A64HookFunction((void*)getRealOffset(addr_ ## name),(void*) hook_ ## name, (void
 )
 
 #define INSTALL_HOOK_OFFSETLESS(name, methodInfo) MACRO_WRAP( \
-log(INFO, "Installing 64 bit offsetless hook: %s", #name); \
+log(INFO, "Installing 64 bit offsetless hook: %s at %lX", #name, asOffset(methodInfo->methodPointer)); \
 A64HookFunction((void*)methodInfo->methodPointer,(void*) hook_ ## name, (void**)&name); \
 )
 
@@ -222,7 +222,7 @@ A64HookFunction((void*)getRealOffset(addr_ ## name),(void*)name, (void**)nullptr
 )
 
 #define UNINSTALL_HOOK_OFFSETLESS(name, methodInfo) MACRO_WRAP( \
-log(INFO, "Uninstalling 64 bit offsetless hook: %s", #name); \
+log(INFO, "Installing 64 bit offsetless hook: %s at %lX", #name, asOffset(methodInfo->methodPointer)); \
 A64HookFunction((void*)methodInfo->methodPointer,(void*)name, (void**)nullptr); \
 )
 

--- a/shared/utils/utils.h
+++ b/shared/utils/utils.h
@@ -222,7 +222,7 @@ A64HookFunction((void*)getRealOffset(addr_ ## name),(void*)name, (void**)nullptr
 )
 
 #define UNINSTALL_HOOK_OFFSETLESS(name, methodInfo) MACRO_WRAP( \
-log(INFO, "Installing 64 bit offsetless hook: %s at %lX", #name, asOffset(methodInfo->methodPointer)); \
+log(INFO, "Uninstalling 64 bit offsetless hook: %s", #name); \
 A64HookFunction((void*)methodInfo->methodPointer,(void*)name, (void**)nullptr); \
 )
 
@@ -245,7 +245,7 @@ inlineHook((uint32_t)getRealOffset(addr_ ## name)); \
 )
 
 #define INSTALL_HOOK_OFFSETLESS(name, methodInfo) MACRO_WRAP( \
-log(INFO, "Installing 32 bit offsetless hook!"); \
+log(INFO, "Installing 32 bit offsetless hook: %s at %lX", #name, asOffset(methodInfo->methodPointer)); \
 registerInlineHook((uint32_t)methodInfo->methodPointer, (uint32_t)hook_ ## name, (uint32_t **)&name); \
 inlineHook((uint32_t)methodInfo->methodPointer); \
 )


### PR DESCRIPTION
.... regardless of the field type.
Before, since we only used `void il2cpp_field_get_value(Il2CppObject *obj, FieldInfo *field, void *value)` for all instance fields, it would unbox value types regardless of what type we asked for, even when it didn't make sense (such as assigning an enum value to an Il2CppObject*, resulting in an invalid pointer).

Now, when you ask GetField for an Il2CppObject* (i.e. by `il2cpp_utils::GetField(` or even `il2cpp_utils::GetField<Il2CppArray*>(` it will properly give you a boxed value, which is good for getting an enum value to pass to RunMethod that remembers its actual type instead of just claiming to be an int (when you used `GetField<int>`) or crashing when the type extractor attempts to get the type from the so-called "Il2CppObject*" (which is what happened previously).

And yes, I examined the code and field_get_value_object also behaves correctly for static fields, and won't even look at the "instance".