### PR TITLE
is_value_type tweaks

### DIFF
--- a/shared/utils/typedefs.h
+++ b/shared/utils/typedefs.h
@@ -27,7 +27,7 @@
 template<class T, class Enable = void>
 struct is_value_type : std::integral_constant< 
     bool,
-    (std::is_arithmetic_v<T> || std::is_enum_v<T> || std::is_pointer_v<T>) && !std::is_base_of_v<Il2CppObject, T>
+    (std::is_arithmetic_v<T> || std::is_enum_v<T> || std::is_pointer_v<T> || std::is_pod_v<T>) && !std::is_base_of_v<Il2CppObject, T>
 > {};
 template<class _T> using is_value_type_v = typename is_value_type<_T>::value;
 

--- a/shared/utils/typedefs.h
+++ b/shared/utils/typedefs.h
@@ -24,7 +24,7 @@
 #include "utils/StringUtils.h"
 
 #ifdef __cplusplus
-template<class T>
+template<class T, class Enable = void>
 struct is_value_type : std::integral_constant< 
     bool,
     (std::is_arithmetic_v<T> || std::is_enum_v<T> || std::is_pointer_v<T>) && !std::is_base_of_v<Il2CppObject, T>


### PR DESCRIPTION
added `|| is_pod` for Color, etc.

I figured this, combined with
```cpp
template<class T>
struct is_value_type<T, typename std::enable_if_t<std::is_base_of_v<System::ValueType, T>>> : std::true_type{};
```
in [Il2Cpp-Modding-Codegen](https://github.com/sc2ad/Il2Cpp-Modding-Codegen)'s System/ValueType.hpp, was the best way to make all descendants of ValueType satisfy is_value_type automatically (and thus be usable as Array<> template types) without requiring bs-hook to know about System/ValueType.hpp