### PR TITLE
DEFINE_Il2CPP_ARG_TYPE_GENERIC restructure to allow for nested types of template types

### DIFF
--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -218,6 +218,57 @@ namespace il2cpp_utils {
         #undef has_obj
         #undef has_object
 
+        template<template<typename... ST> class S>
+        struct il2cpp_gen_struct_arg_class;
+
+        template<template<typename... ST> class S>
+        struct il2cpp_gen_class_arg_class;
+
+        template<typename... TArgs, template<typename... ST> class S>
+        struct ::il2cpp_utils::il2cpp_type_check::il2cpp_arg_class<S<TArgs...>> {
+            static inline Il2CppClass* get() {
+                auto* klass = il2cpp_gen_struct_arg_class<S>::get();
+                return il2cpp_utils::MakeGeneric(klass, {il2cpp_arg_class<TArgs>::get()...});
+            }
+            static inline Il2CppClass* get(S<TArgs...> arg) { return get(); }
+        };
+
+        template<typename... TArgs, template<typename... ST> class S>
+        struct ::il2cpp_utils::il2cpp_type_check::il2cpp_arg_class<S<TArgs...>*> {
+            static inline Il2CppClass* get() {
+                Il2CppClass* genTemplate;
+                bool isStruct = false;
+                if constexpr (has_no_arg_get<il2cpp_gen_class_arg_class<S>>) {
+                    genTemplate = il2cpp_gen_class_arg_class<S>::get();
+                } else {
+                    genTemplate = il2cpp_gen_struct_arg_class<S>::get();
+                    isStruct = true;
+                }
+                auto* genInst = il2cpp_utils::MakeGeneric(genTemplate, {il2cpp_arg_class<TArgs>::get()...});
+                if (isStruct) {
+                    return il2cpp_functions::Class_GetPtrClass(genInst);
+                }
+                return genInst;
+            }
+            static inline Il2CppClass* get(S<TArgs...>* arg) { return get(); }
+        };
+
+        #define DEFINE_IL2CPP_ARG_TYPE_GENERIC_STRUCT(templateType, nameSpace, className) \
+        template<> \
+        struct ::il2cpp_utils::il2cpp_type_check::il2cpp_gen_struct_arg_class<templateType> { \
+            static inline Il2CppClass* get() { \
+                return il2cpp_utils::GetClassFromName(nameSpace, className); \
+            } \
+        }
+
+        #define DEFINE_IL2CPP_ARG_TYPE_GENERIC_CLASS(templateType, nameSpace, className) \
+        template<> \
+        struct ::il2cpp_utils::il2cpp_type_check::il2cpp_gen_class_arg_class<templateType> { \
+            static inline Il2CppClass* get() { \
+                return il2cpp_utils::GetClassFromName(nameSpace, className); \
+            } \
+        }
+
         template<typename T>
         struct il2cpp_arg_type { };
 


### PR DESCRIPTION
Also removes the weird "postfix" stuff.
The macros, DEFINE_IL2CPP_ARG_TYPE_GENERIC_STRUCT and DEFINE_IL2CPP_ARG_TYPE_GENERIC_CLASS, now accept a template name, followed by the usual namespace and class name strings.
A "template name" is a name that refers to a template type. It cannot contain any <> in it.
If it would, then alias it first, i.e.
```
  template<typename T>
  using List_1_Enumerator = typename List_1<T>::Enumerator;
```
allows you to use `List_1_Enumerator` as a template name.

The 2 different macros simply tell the system whether the template should be a C# value type (_STRUCT) or reference type (_CLASS).
This means that if someone passes a pointer to an instance of this template, then for a _CLASS, it will simply be inferred as the class you named in the macro.
However, for a _STRUCT, a pointer will be added to the final class (after it is properly genericized).
Likewise, if they _don't_ pass the instance as a pointer, but instead use it directly as the template type, then inferrence will fail for a _CLASS, and work as normal for a _STRUCT.