### PR TITLE
Type inference arg vs no-arg rewrite.

### DIFF
--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -163,9 +163,9 @@ namespace il2cpp_utils {
 
         DEFINE_IL2CPP_DEFAULT_TYPE(bool, boolean);
         DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppChar, char);
-        DEFINE_IL2CPP_DEFAULT_TYPE(void, void);
 
         #ifdef NEED_UNSAFE_CSHARP
+        DEFINE_IL2CPP_DEFAULT_TYPE(void, void);
         DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppObject*, object);
         #endif
         DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppString*, string);

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -163,6 +163,7 @@ namespace il2cpp_utils {
 
         DEFINE_IL2CPP_DEFAULT_TYPE(bool, boolean);
         DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppChar, char);
+        DEFINE_IL2CPP_DEFAULT_TYPE(void, void);
 
         #ifdef NEED_UNSAFE_CSHARP
         DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppObject*, object);


### PR DESCRIPTION
The macros only define the class for no-arg.
For class given arg, it extracts from the object if T (psuedo)extends Il2CppObject; otherwise it calls the no-arg version.
Also fixes ExtractIndependentType.