### PR TITLE
Remove convertible to Il2CppObject in favor of more conservative checks

### DIFF
--- a/shared/utils/il2cpp-type-check.hpp
+++ b/shared/utils/il2cpp-type-check.hpp
@@ -162,6 +162,8 @@ namespace il2cpp_utils {
             }
         };
 
+        // TODO: is_il2cpp_object type trait?
+
         template<typename T>
         struct il2cpp_arg_class<T*> {
             static inline Il2CppClass* get(T* arg) {


### PR DESCRIPTION
All my other mods still worked when tested with this.
Fixes at least one (probably more) bug where getting a bool from an Il2CppObject* could sometimes just evaluate the pointer as bool