### PR TITLE
Return type tie-breaking added.

### DIFF
--- a/shared/utils/il2cpp-type-check.hpp
+++ b/shared/utils/il2cpp-type-check.hpp
@@ -5,18 +5,18 @@
 #if __has_include(<concepts>)
 #include <concepts>
 template<typename T>
-constexpr bool has_no_arg_get = requires(const T& t) {
-    t.get();
+constexpr bool has_get = requires(const T& t) {
+    t.get;
 };
 #elif __has_include(<experimental/type_traits>)
 #include <experimental/type_traits>
 template<typename T>
-using no_arg_get_t = decltype( T::get() );
+using get_t = decltype( &T::get );
 
 template<typename T>
-constexpr bool has_no_arg_get = std::experimental::is_detected_v<no_arg_get_t, T>;
+constexpr bool has_get = std::experimental::is_detected_v<get_t, T>;
 #else
-#error No libraries for the implementation of has_no_arg_get available!
+#error No libraries for the implementation of has_get available!
 #endif
 
 #include "utils.h"
@@ -79,7 +79,10 @@ namespace il2cpp_utils {
         template<typename T>
         struct il2cpp_arg_class {
             static inline Il2CppClass* get([[maybe_unused]] T arg) {
-                return il2cpp_no_arg_class<T>::get();
+                if constexpr (has_get<il2cpp_no_arg_class<T>>) {
+                    return il2cpp_no_arg_class<T>::get();
+                }
+                return nullptr;
             }
         };
 
@@ -167,11 +170,11 @@ namespace il2cpp_utils {
             static inline Il2CppClass* get(T* arg) {
                 using ptr_arg_class = il2cpp_no_arg_class<T*>;
                 using element_arg_class = il2cpp_no_arg_class<T>;
-                if constexpr (has_no_arg_get<ptr_arg_class>) {
+                if constexpr (has_get<ptr_arg_class>) {
                     if (!arg)
                         return ptr_arg_class::get();
                     // otherwise, falls through to Il2CppObject* handler
-                } else if constexpr (has_no_arg_get<element_arg_class>) {
+                } else if constexpr (has_get<element_arg_class>) {
                     Il2CppClass* elementClass = element_arg_class::get();
                     return il2cpp_functions::Class_GetPtrClass(elementClass);
                 }
@@ -199,9 +202,9 @@ namespace il2cpp_utils {
             static inline Il2CppClass* get() {
                 Il2CppClass* genTemplate;
                 bool isStruct = false;
-                if constexpr (has_no_arg_get<il2cpp_gen_class_no_arg_class<S>>) {
+                if constexpr (has_get<il2cpp_gen_class_no_arg_class<S>>) {
                     genTemplate = il2cpp_gen_class_no_arg_class<S>::get();
-                } else if constexpr (has_no_arg_get<il2cpp_gen_struct_no_arg_class<S>>) {
+                } else if constexpr (has_get<il2cpp_gen_struct_no_arg_class<S>>) {
                     genTemplate = il2cpp_gen_struct_no_arg_class<S>::get();
                     isStruct = true;
                 } else {

--- a/shared/utils/il2cpp-type-check.hpp
+++ b/shared/utils/il2cpp-type-check.hpp
@@ -115,13 +115,11 @@ namespace il2cpp_utils {
         DEFINE_IL2CPP_DEFAULT_TYPE(bool, boolean);
         DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppChar, char);
 
-        #ifdef NEED_UNSAFE_CSHARP
         DEFINE_IL2CPP_DEFAULT_TYPE(void, void);
         DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppObject*, object);
-        #endif
         DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppString*, string);
+        DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppArray*, array);
         DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionType*, systemtype);
-        DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionRuntimeType*, runtimetype);
 
         DEFINE_IL2CPP_ARG_TYPE(long double, "System", "Decimal");
         DEFINE_IL2CPP_ARG_TYPE(Color, "UnityEngine", "Color");

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -48,21 +48,71 @@ namespace il2cpp_utils {
 
     bool IsInterface(const Il2CppClass* klass);
 
+    // Function made by zoller27osu, modified by Sc2ad
+    // Logs information about the given MethodInfo* as log(DEBUG)
+    void LogMethod(const MethodInfo* method);
+
+    // Created by zoller27osu
+    // Calls LogMethod on all methods in the given class
+    void LogMethods(Il2CppClass* klass, bool logParents = false);
+
+    // Created by zoller27osu
+    // Logs information about the given FieldInfo* as log(DEBUG)
+    void LogField(FieldInfo* field);
+
+    // Created by zoller27osu
+    // Calls LogField on all fields in the given class
+    void LogFields(Il2CppClass* klass, bool logParents = false);
+
+    // Created by zoller27osu
+    // Logs information about the given PropertyInfo* as log(DEBUG)
+    void LogProperty(const PropertyInfo* field);
+
+    // Created by zoller27osu
+    // Calls LogProperty on all properties in the given class
+    void LogProperties(Il2CppClass* klass, bool logParents = false);
+
+    // Some parts provided by zoller27osu
+    // Logs information about the given Il2CppClass* as log(DEBUG)
+    void LogClass(Il2CppClass* klass, bool logParents = false);
+
+    // Logs all classes (from every namespace) that start with the given prefix
+    // WARNING: THIS FUNCTION IS VERY SLOW. ONLY USE THIS FUNCTION ONCE AND WITH A FAIRLY SPECIFIC PREFIX!
+    void LogClasses(std::string_view classPrefix, bool logParents = false);
+
+    // "Calling" this gives a compile-time warning (if warnings from this header are enabled)
+    template<class T>
+    [[deprecated]]void a_lack_of_no_arg_class_for([[maybe_unused]]std::string_view s) {};
+
     template<typename T>
-    Il2CppClass* ExtractClass(T&& arg) {
-        Il2CppClass* klass = il2cpp_type_check::il2cpp_arg_class<std::decay_t<T>>::get(arg);
-        if (!klass) {
+    Il2CppClass* ExtractClass(T&& arg, bool silent = false) {
+        using Dt = std::decay_t<T>;
+        using arg_class = il2cpp_type_check::il2cpp_arg_class<Dt>;
+        Il2CppClass* klass = arg_class::get(arg);
+        if (!silent && !klass)
             Logger::get().error("ExtractClass: failed to determine class! Tips: instead of nullptr, pass the Il2CppType* or Il2CppClass* of the argument instead!");
-        }
         return klass;
+    }
+
+    template<class T, bool ResultRequired = false>
+    Il2CppClass* NoArgClass() {
+        using arg_class = il2cpp_type_check::il2cpp_no_arg_class<T>;
+        if constexpr (has_get<arg_class>) {
+            return CRASH_UNLESS(arg_class::get());
+        } else if constexpr(ResultRequired) {
+            static_assert(false_t<il2cpp_type_check::il2cpp_no_arg_class<T>>,
+                "il2cpp-type-check.hpp could not deduce what C# type your type represents");
+        } else {
+            a_lack_of_no_arg_class_for<T>("please tell il2cpp-type-check.hpp what C# type your type represents");
+        }
+        return nullptr;
     }
 
     template<typename T>
     const Il2CppType* ExtractType(T&& arg) {
         const Il2CppType* typ = il2cpp_type_check::il2cpp_arg_type<T>::get(arg);
-        if (!typ) {
+        if (!typ)
             Logger::get().error("ExtractType: failed to determine type! Tips: instead of nullptr, pass the Il2CppType* or Il2CppClass* of the argument instead!");
-        }
         return typ;
     }
 
@@ -76,6 +126,13 @@ namespace il2cpp_utils {
         auto tOthers = ExtractTypes(args...);
         if (tFirst) tOthers.insert(tOthers.begin(), tFirst);
         return tOthers;
+    }
+
+    // Like ExtractType, but only returns an Il2CppType* if it can be extracted without an instance of T.
+    template<class T>
+    const Il2CppType* ExtractIndependentType() {
+        auto* klass = RET_0_UNLESS(NoArgClass<T>());
+        return il2cpp_functions::class_get_type(klass);
     }
 
     // Returns if a given MethodInfo's parameters match the Il2CppType vector
@@ -189,29 +246,48 @@ namespace il2cpp_utils {
     bool IsConvertible(const Il2CppType* to, const Il2CppType* from, bool asArgs = true);
 
     template<class T>
-    [[deprecated]]void a_lack_of_no_arg_class_for([[maybe_unused]]std::string_view s) {};
+    Il2CppObject* ToIl2CppObject(T&& arg) {
+        il2cpp_functions::Init();
 
-    template<class T>
-    Il2CppClass* NoArgClass() {
-        using arg_class = il2cpp_type_check::il2cpp_no_arg_class<T>;
-        if constexpr (has_no_arg_get<arg_class>) {
-            return CRASH_UNLESS(arg_class::get());
-        } else {
-            a_lack_of_no_arg_class_for<T>("please tell il2cpp-type-check.hpp what C# type your type represents");
-        }
-        return nullptr;
+        using Dt = std::decay_t<T>;
+        if constexpr (std::is_same_v<Dt, Il2CppType*> || std::is_same_v<Dt, Il2CppClass*>) {
+            return nullptr;
+        } /* else if constexpr (std::is_pointer_v<Dt> && std::is_base_of_v<Il2CppObject, std::remove_pointer_t<Dt>>) {
+            return static_cast<Il2CppObject*>(arg);
+        } */
+        auto* klass = RET_0_UNLESS(ExtractClass(arg));
+        return il2cpp_functions::value_box(klass, &arg);
     }
 
-    // Like ExtractType, but only returns an Il2CppType* if it can be extracted without an instance of T.
-    template<class T>
-    const Il2CppType* ExtractIndependentType() {
-        using arg_class = il2cpp_type_check::il2cpp_no_arg_class<T>;
-        if constexpr (has_no_arg_get<arg_class>) {
-            il2cpp_functions::Init();
-            auto* klass = CRASH_UNLESS(arg_class::get());
-            return il2cpp_functions::class_get_type(klass);
+    template<class TOut>
+    std::optional<TOut> FromIl2CppObject(Il2CppObject* obj) {
+        il2cpp_functions::Init();
+
+        // using Dt = std::decay_t<TOut>;
+        void* val = obj;
+        // nullptr (which runtime_invoke returns for "void" return type!) is different from nullopt (a runtime_invoke error!)
+        if (obj && il2cpp_functions::class_is_valuetype(il2cpp_functions::object_get_class(obj)))
+            val = RET_NULLOPT_UNLESS(il2cpp_functions::object_unbox(obj));
+        if constexpr (std::is_pointer_v<TOut>) {
+            return static_cast<TOut>(val);
+        } else {
+            return *static_cast<TOut*>(val);
         }
-        return nullptr;
+    }
+
+    template<class T>
+    bool FromIl2CppObject(Il2CppObject* obj, T& out) {
+        using Dt = std::decay_t<T>;
+        if (auto ret = FromIl2CppObject<Dt>(obj)) {
+            if constexpr (std::is_pointer_v<Dt>) {
+                // if they asked for the output in a pointer, we shouldn't change the pointer itself
+                *out = *(*ret);
+            } else {
+                out = *ret;
+            }
+            return true;
+        }
+        return false;
     }
 
     template<class TOut = Il2CppObject*, bool checkTypes = true, class T, class... TArgs>
@@ -245,25 +321,13 @@ namespace il2cpp_utils {
             }
         }
 
-        // Convert the Il2CppObject* we got from runtime_invoke to TOut.
-        TOut out;
-        if constexpr (std::is_pointer_v<TOut>) {
-            using Dt = std::decay_t<TOut>;
-            if constexpr (std::is_base_of_v<Il2CppObject, std::remove_pointer_t<Dt>>) {
-                out = static_cast<TOut>(static_cast<Il2CppObject*>(ret));
-            } else {
-                out = reinterpret_cast<TOut>(ret);
-            }
-        } else {
-            out = *reinterpret_cast<TOut*>(il2cpp_functions::object_unbox(ret));
-        }
-
         if (exp) {
             Logger::get().error("il2cpp_utils: RunMethod: %s: Failed with exception: %s", il2cpp_functions::method_get_name(method),
                 il2cpp_utils::ExceptionToString(exp).c_str());
             return std::nullopt;
         }
-        return out;
+
+        return FromIl2CppObject<TOut>(ret);
     }
 
     template<class TOut = Il2CppObject*, class T, class... TArgs>
@@ -343,46 +407,55 @@ namespace il2cpp_utils {
         return RunGenericMethod<TOut>(klass, methodName, genTypes, params...);
     }
 
-    template<typename TObj = Il2CppObject, typename... TArgs>
-    // Creates a new object of the given class using the given constructor parameters and casts it to TObj*
+    template<typename TOut = Il2CppObject*, typename... TArgs>
+    // Creates a new object of the given class using the given constructor parameters
     // Will only run a .ctor whose parameter types match the given arguments.
-    TObj* New(Il2CppClass* klass, TArgs&& ...args) {
+    std::optional<TOut> New(Il2CppClass* klass, TArgs&& ...args) {
         il2cpp_functions::Init();
 
         // object_new call
-        auto* obj = RET_0_UNLESS(reinterpret_cast<TObj*>(il2cpp_functions::object_new(klass)));
+        Il2CppObject* obj = RET_NULLOPT_UNLESS(il2cpp_functions::object_new(klass));
         // runtime_invoke constructor with right type(s) of arguments, return null if constructor errors
-        RET_0_UNLESS(RunMethod(obj, ".ctor", args...));
-        return obj;
+        RET_NULLOPT_UNLESS(RunMethod(obj, ".ctor", args...));
+        return FromIl2CppObject<TOut>(obj);
     }
 
-    template<typename TObj = Il2CppObject, typename... TArgs>
-    // Creates a new object of the given class using the given constructor parameters and casts it to TObj*
+    template<typename TOut = Il2CppObject*, typename... TArgs>
+    // Creates a new object of the given class using the given constructor parameters
     // DOES NOT PERFORM ARGUMENT TYPE CHECKING! Uses the first .ctor with the right number of parameters it sees.
-    TObj* NewUnsafe(Il2CppClass* klass, TArgs* ...args) {
+    std::optional<TOut> NewUnsafe(Il2CppClass* klass, TArgs* ...args) {
         il2cpp_functions::Init();
 
         // object_new call
-        auto* obj = RET_0_UNLESS(reinterpret_cast<TObj*>(il2cpp_functions::object_new(klass)));
+        Il2CppObject* obj = RET_NULLOPT_UNLESS(il2cpp_functions::object_new(klass));
         // runtime_invoke constructor with right number of args, return null if constructor errors
-        RET_0_UNLESS(RunMethodUnsafe(obj, ".ctor", args...));
-        return obj;
+        RET_NULLOPT_UNLESS(RunMethodUnsafe(obj, ".ctor", args...));
+        return FromIl2CppObject<TOut>(obj);
     }
 
-    template<typename TObj = Il2CppObject, typename... TArgs>
-    // Creates a new object of the class with the given nameSpace and className using the given constructor parameters and casts
-    // it to TObj*. Will only run a .ctor whose parameter types match the given arguments.
-    TObj* New(std::string_view nameSpace, std::string_view className, TArgs&& ...args) {
-        auto* klass = RET_0_UNLESS(GetClassFromName(nameSpace, className));
-        return New<TObj>(klass, args...);
+    template<typename TOut = Il2CppObject*, typename... TArgs>
+    // Creates a new object of the returned type using the given constructor parameters
+    // Will only run a .ctor whose parameter types match the given arguments.
+    std::enable_if_t<(... && (!std::is_convertible_v<Il2CppClass*, TArgs> && !std::is_convertible_v<TArgs, std::string_view>)),
+    std::optional<TOut>> New(TArgs&& ...args) {
+        auto* klass = RET_NULLOPT_UNLESS((NoArgClass<TOut, true>()));
+        return New<TOut>(klass, args...);
     }
 
-    template<typename TObj = Il2CppObject, typename... TArgs>
-    // Creates a new object of the class with the given nameSpace and className using the given constructor parameters and casts
-    // it to TObj*. DOES NOT PERFORM ARGUMENT TYPE CHECKING! Uses the first .ctor with the right number of parameters it sees.
-    TObj* NewUnsafe(std::string_view nameSpace, std::string_view className, TArgs* ...args) {
+    template<typename TOut = Il2CppObject*, typename... TArgs>
+    // Creates a new object of the class with the given nameSpace and className using the given constructor parameters.
+    // Will only run a .ctor whose parameter types match the given arguments.
+    std::optional<TOut> New(std::string_view nameSpace, std::string_view className, TArgs&& ...args) {
         auto* klass = RET_0_UNLESS(GetClassFromName(nameSpace, className));
-        return NewUnsafe<TObj>(klass, args...);
+        return New<TOut>(klass, args...);
+    }
+
+    template<typename TOut = Il2CppObject*, typename... TArgs>
+    // Creates a new object of the class with the given nameSpace and className using the given constructor parameters.
+    // DOES NOT PERFORM ARGUMENT TYPE CHECKING! Uses the first .ctor with the right number of parameters it sees.
+    std::optional<TOut> NewUnsafe(std::string_view nameSpace, std::string_view className, TArgs* ...args) {
+        auto* klass = RET_0_UNLESS(GetClassFromName(nameSpace, className));
+        return NewUnsafe<TOut>(klass, args...);
     }
 
     // Returns the FieldInfo for the field of the given class with the given name
@@ -427,48 +500,12 @@ namespace il2cpp_utils {
         return out;
     }
 
-    template<class T>
-    Il2CppObject* ExtractObject(T&& arg) {
-        il2cpp_functions::Init();
-
-        using Dt = std::decay_t<T>;
-        if constexpr (std::is_same_v<Dt, Il2CppType*> || std::is_same_v<Dt, Il2CppClass*>) {
-            return nullptr;
-        } else if constexpr (std::is_pointer_v<Dt> && std::is_base_of_v<Il2CppObject, std::remove_pointer_t<Dt>>) {
-            return static_cast<Il2CppObject*>(arg);
-        }
-        auto* klass = RET_0_UNLESS(ExtractClass(arg));
-        return il2cpp_functions::value_box(klass, &arg);
-    }
-
-    template<class T>
-    bool UnextractObject(T& orig, Il2CppObject* modified) {
-        il2cpp_functions::Init();
-        if (!modified) return true;
-
-        using Dt = std::decay_t<T>;
-        if constexpr (std::is_pointer_v<Dt> && std::is_base_of_v<Il2CppObject, std::remove_pointer_t<Dt>>) {
-            orig = static_cast<T>(modified);
-        } else {
-            void* val = modified;
-            if (il2cpp_functions::class_is_valuetype(il2cpp_functions::object_get_class(modified)))
-                val = RET_0_UNLESS(il2cpp_functions::object_unbox(modified));
-            if constexpr (std::is_pointer_v<Dt>) {
-                // TODO: would orig = static_cast<Dt>(val); work?
-                *orig = *static_cast<Dt>(val);
-            } else {
-                orig = *static_cast<Dt*>(val);
-            }
-        }
-        return true;
-    }
-
     template<typename TOut = Il2CppObject*, typename T>
     // Gets the value of the field with type TOut and the given name from the given class
     // Adapted by zoller27osu
     std::optional<TOut> GetFieldValue(T&& classOrInstance, std::string_view fieldName) {
         auto* field = RET_NULLOPT_UNLESS(FindField(classOrInstance, fieldName));
-        Il2CppObject* obj = ExtractObject(classOrInstance);  // null is allowed (for T = Il2CppType* or Il2CppClass*)
+        Il2CppObject* obj = ToIl2CppObject(classOrInstance);  // null is allowed (for T = Il2CppType* or Il2CppClass*)
         return GetFieldValue<TOut>(obj, field);
     }
 
@@ -507,9 +544,9 @@ namespace il2cpp_utils {
     template<class T, class TArg>
     bool SetFieldValue(T& classOrInstance, std::string_view fieldName, TArg&& value) {
         auto* field = RET_0_UNLESS(FindField(classOrInstance, fieldName));
-        Il2CppObject* obj = ExtractObject(classOrInstance);  // null is allowed (for T = Il2CppType* or Il2CppClass*)
+        Il2CppObject* obj = ToIl2CppObject(classOrInstance);  // null is allowed (for T = Il2CppType* or Il2CppClass*)
         RET_0_UNLESS(SetFieldValue(obj, field, value));
-        RET_0_UNLESS(UnextractObject(classOrInstance, obj));
+        if (obj) RET_0_UNLESS(FromIl2CppObject(classOrInstance, obj));
         return true;
     }
 
@@ -681,38 +718,6 @@ namespace il2cpp_utils {
 
     // Calls the System.RuntimeType.MakeGenericType(System.Type gt, System.Type[] types) function
     Il2CppReflectionType* MakeGenericType(Il2CppReflectionType* gt, Il2CppArray* types);
-
-    // Function made by zoller27osu, modified by Sc2ad
-    // Logs information about the given MethodInfo* as log(DEBUG)
-    void LogMethod(const MethodInfo* method);
-
-    // Created by zoller27osu
-    // Calls LogMethod on all methods in the given class
-    void LogMethods(Il2CppClass* klass, bool logParents = false);
-
-    // Created by zoller27osu
-    // Logs information about the given FieldInfo* as log(DEBUG)
-    void LogField(FieldInfo* field);
-
-    // Created by zoller27osu
-    // Calls LogField on all fields in the given class
-    void LogFields(Il2CppClass* klass, bool logParents = false);
-
-    // Created by zoller27osu
-    // Logs information about the given PropertyInfo* as log(DEBUG)
-    void LogProperty(const PropertyInfo* field);
-
-    // Created by zoller27osu
-    // Calls LogProperty on all properties in the given class
-    void LogProperties(Il2CppClass* klass, bool logParents = false);
-
-    // Some parts provided by zoller27osu
-    // Logs information about the given Il2CppClass* as log(DEBUG)
-    void LogClass(Il2CppClass* klass, bool logParents = false);
-
-    // Logs all classes (from every namespace) that start with the given prefix
-    // WARNING: THIS FUNCTION IS VERY SLOW. ONLY USE THIS FUNCTION ONCE AND WITH A FAIRLY SPECIFIC PREFIX!
-    void LogClasses(std::string_view classPrefix, bool logParents = false);
 
     // Adds the given TypeDefinitionIndex to the class hash table of a given image
     // Mainly used in LogClasses

--- a/shared/utils/typedefs.h
+++ b/shared/utils/typedefs.h
@@ -531,7 +531,42 @@ typedef System::Threading::InternalThread Il2CppInternalThread;
 #include "System/Threading/Thread.hpp"
 // self-typedef'd in il2cpp-api-types.h
 struct Il2CppThread : public System::Threading::Thread {};
+
+#else
+// From Runtime.cpp (some may need the * removed):
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppMulticastDelegate*, multicastdelegate);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppAsyncCall*, async_call);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppInternalThread*, internal_thread);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionEvent*, event_info);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppStringBuilder*, stringbuilder);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppStackFrame*, stack_frame);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionAssemblyName*, assembly_name);
+// DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionAssembly*, assembly);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionAssembly*, mono_assembly);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionField*, mono_field);
+// DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionParameter*, parameter_info);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionParameter*, mono_parameter_info);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionModule*, module);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionPointer*, pointer);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppSystemException*, system_exception);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppArgumentException*, argument_exception);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppMarshalByRefObject*, marshalbyrefobject);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppSafeHandle*, safe_handle);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppSortKey*, sort_key);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppErrorWrapper*, error_wrapper);
+// TODO: attempt to move out of this conditional if codegen ever gets an Il2CppComObject?
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppComObject*, il2cpp_com_object);
 #endif
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppDelegate*, delegate);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionMonoType*, monotype);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppThread*, thread);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionRuntimeType*, runtimetype);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionMonoEventInfo*, mono_event_info);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppTypedRef*, typed_reference);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppReflectionMethod*, mono_method);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppMethodInfo*, mono_method_info);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppPropertyInfo*, mono_property_info);
+DEFINE_IL2CPP_DEFAULT_TYPE(Il2CppException*, exception);
 
 #include "utils/Il2CppHashMap.h"
 #include "utils/HashUtils.h"


### PR DESCRIPTION
Tested with the following code:
```cpp
    // Context: System::Decimal has multiple op_Explicit, with return types of float and double.
    // Prior to this PR, attempting to call either with a "safe" RunMethod would fail due to multiple match.
    Il2CppObject* decObj = (Il2CppObject*)CRASH_UNLESS(System::Decimal::New_ctor(3));
    auto* dec = reinterpret_cast<System::Decimal*>(il2cpp_functions::object_unbox(decObj));
    logger().info("dec to string: %s", to_utf8(csstrtostr(dec->ToString())).c_str());
    auto* method = CRASH_UNLESS(il2cpp_utils::FindMethod(
        "System", "Decimal", il2cpp_functions::defaults->single_class, "op_Explicit", "System", "Decimal"));
    il2cpp_utils::LogMethod(method);
    logger().info("dec as float: %f", CRASH_UNLESS((il2cpp_utils::RunMethod<float, false>(nullptr, method, *dec))));

    decObj = (Il2CppObject*)CRASH_UNLESS(System::Decimal::New_ctor(1.337f));
    dec = (System::Decimal*)il2cpp_functions::object_unbox(decObj);
    logger().info("dec to string: %s", to_utf8(csstrtostr(dec->ToString())).c_str());
    logger().info("dec as float: %f", CRASH_UNLESS((il2cpp_utils::RunMethod<float>("System", "Decimal", "op_Explicit", *dec))));

    dec = CRASH_UNLESS(il2cpp_utils::New<System::Decimal*>("System", "Decimal", 420.69f));
    logger().info("dec to string: %s", to_utf8(csstrtostr(dec->ToString())).c_str());
    logger().info("dec as float: %f", CRASH_UNLESS((il2cpp_utils::RunMethod<float>("System", "Decimal", "op_Explicit", *dec))));

    auto d = CRASH_UNLESS(il2cpp_utils::New<System::Decimal>(867530.9f));
    logger().info("dec to string: %s", to_utf8(csstrtostr(d.ToString())).c_str());
    logger().info("dec as float: %f", CRASH_UNLESS((il2cpp_utils::RunMethod<float>("System", "Decimal", "op_Explicit", d))));

    // This last one should (and does) crash, because multiple of the candidates implement this interface.
    logger().info("dec as IConvertible: %p", CRASH_UNLESS((il2cpp_utils::RunMethod<System::IConvertible*>("System", "Decimal", "op_Explicit", d))));
```