### PR TITLE
no rtti. no_arg value-type pointers.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -32,12 +32,11 @@ LOCAL_SRC_FILES := extern/libmodloader.so
 include $(PREBUILT_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
-LOCAL_MODULE := beatsaber-hook
+LOCAL_MODULE := beatsaber-hook_0_5_9
 LOCAL_SRC_FILES += $(call rwildcard,src/utils,*.cpp)
 LOCAL_SRC_FILES += $(call rwildcard,src/config,*.cpp)
 LOCAL_SHARED_LIBRARIES += modloader
 LOCAL_LDLIBS += -llog
-LOCAL_CFLAGS += -DVERSION='"0.3.9"' -isystem 'extern/libil2cpp/il2cpp/libil2cpp' -D'UNITY_2019' -Wall -Wextra -Werror -Wno-unused-function -DID='"beatsaber-hook"' -I'./shared' -isystem 'extern' -isystem 'extern/codegen/include'
+LOCAL_CFLAGS += -DVERSION='"0.5.9"' -isystem 'extern/libil2cpp/il2cpp/libil2cpp' -D'UNITY_2019' -Wall -Wextra -Werror -Wno-unused-function -DID='"beatsaber-hook"' -I'./shared' -isystem 'extern' -isystem 'extern/codegen/include'
 LOCAL_C_INCLUDES += ./shared
-LOCAL_CPP_FEATURES += rtti
 include $(BUILD_SHARED_LIBRARY)

--- a/qpm.json
+++ b/qpm.json
@@ -4,7 +4,7 @@
   "info": {
     "name": "beatsaber-hook",
     "id": "beatsaber-hook",
-    "version": "0.3.9",
+    "version": "0.5.9",
     "url": "https://github.com/sc2ad/beatsaber-hook",
     "additionalData": {
       "branchName": "so-update",

--- a/shared/utils/il2cpp-type-check.hpp
+++ b/shared/utils/il2cpp-type-check.hpp
@@ -32,7 +32,9 @@ namespace il2cpp_utils {
 
     // Framework provided by DaNike
     namespace il2cpp_type_check {
-        // You should extend this class for any nested/inner type of a generic type, and also put a `using declaring_type = Blah;`
+        // You should extend this class for any nested/inner type of a generic type, and also put a
+        // `using declaring_type = Foo<T>*;` (minus the * if it is a value type)
+        // and a `static constexpr std::string_view NESTED_NAME = "Bar";`
         class NestedType {};
         // To fix "no member named 'get' in il2cpp_type_check::il2cpp_arg_class<Blah>", just define il2cpp_no_arg_class<Blah>!
         // The macros like DEFINE_IL2CPP_ARG_TYPE make this easy! The only reason to define an il2cpp_arg_class struct is if,
@@ -40,7 +42,16 @@ namespace il2cpp_utils {
         template<typename T, class Enable = void>
         struct il2cpp_no_arg_class { };
 
-        #if __has_feature(cxx_rtti)
+        template<typename T>
+        struct il2cpp_no_arg_class<T*, typename std::enable_if_t<has_get<il2cpp_no_arg_class<T>>>> {
+            static inline Il2CppClass* get() {
+                il2cpp_functions::Init();
+                auto* klass = RET_0_UNLESS(il2cpp_no_arg_class<T>::get());
+                RET_0_UNLESS(il2cpp_functions::class_is_valuetype(klass));
+                return il2cpp_functions::Class_GetPtrClass(klass);
+            }
+        };
+
         template<typename T>
         struct il2cpp_no_arg_class<T, typename std::enable_if_t<std::is_base_of_v<NestedType, T>>> {
             // TODO: make this work on any class with a `using declaring_type`, then remove NestedType
@@ -52,9 +63,13 @@ namespace il2cpp_utils {
                     // Class::GetNestedTypes refuses to work on generic instances, so get the generic template instead
                     classWithNested = CRASH_UNLESS(il2cpp_functions::MetadataCache_GetTypeInfoFromTypeDefinitionIndex(declaring->generic_class->typeDefinitionIndex));
                 }
+                #if __has_feature(cxx_rtti)
                 std::string typeName = type_name<T>();
                 auto idx = typeName.find_last_of(':');
                 if (idx >= 0) typeName = typeName.substr(idx+1);
+                #else
+                std::string typeName(T::NESTED_NAME);
+                #endif
 
                 // log(INFO, "type_name: %s", typeName.c_str());
                 void* myIter = nullptr;
@@ -71,10 +86,10 @@ namespace il2cpp_utils {
                     const Il2CppGenericInst* genInst = declaring->generic_class->context.class_inst;
                     found = CRASH_UNLESS(il2cpp_utils::MakeGeneric(found, genInst->type_argv, genInst->type_argc));
                 }
+
                 return found;
             }
         };
-        #endif
 
         template<typename T>
         struct il2cpp_arg_class {
@@ -168,18 +183,21 @@ namespace il2cpp_utils {
         template<typename T>
         struct il2cpp_arg_class<T*> {
             static inline Il2CppClass* get(T* arg) {
-                using ptr_arg_class = il2cpp_no_arg_class<T*>;
                 using element_arg_class = il2cpp_no_arg_class<T>;
-                if constexpr (has_get<ptr_arg_class>) {
-                    if (!arg)
-                        return ptr_arg_class::get();
-                    // otherwise, falls through to Il2CppObject* handler
-                } else if constexpr (has_get<element_arg_class>) {
+                if constexpr (has_get<element_arg_class>) {
                     Il2CppClass* elementClass = element_arg_class::get();
                     return il2cpp_functions::Class_GetPtrClass(elementClass);
                 }
-                il2cpp_functions::Init();
-                return RET_0_UNLESS(il2cpp_functions::object_get_class(reinterpret_cast<Il2CppObject*>(arg)));
+                if (arg) {
+                    il2cpp_functions::Init();
+                    auto* klass = il2cpp_functions::object_get_class(reinterpret_cast<Il2CppObject*>(arg));
+                    if (klass && klass->klass == klass) return klass;
+                }
+                using ptr_arg_class = il2cpp_no_arg_class<T*>;
+                if constexpr (has_get<ptr_arg_class>) {
+                    return ptr_arg_class::get();
+                }
+                return nullptr;
             }
         };
 
@@ -190,7 +208,7 @@ namespace il2cpp_utils {
         struct il2cpp_gen_class_no_arg_class;
 
         template<typename... TArgs, template<typename... ST> class S>
-        struct il2cpp_no_arg_class<S<TArgs...>> {
+        struct il2cpp_no_arg_class<S<TArgs...>, typename std::enable_if_t<has_get<il2cpp_gen_struct_no_arg_class<S>>>> {
             static inline Il2CppClass* get() {
                 auto* klass = il2cpp_gen_struct_no_arg_class<S>::get();
                 return il2cpp_utils::MakeGeneric(klass, {il2cpp_no_arg_class<TArgs>::get()...});

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -96,6 +96,7 @@ namespace il2cpp_utils {
 
     template<class T, bool ResultRequired = false>
     Il2CppClass* NoArgClass() {
+        // TODO: change ifndef HAS_CODEGEN to 'if compile warnings are not errors'?
         #ifndef HAS_CODEGEN
         using arg_class = il2cpp_type_check::il2cpp_no_arg_class<T>;
         if constexpr (!has_get<arg_class>) {

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -96,16 +96,18 @@ namespace il2cpp_utils {
 
     template<class T, bool ResultRequired = false>
     Il2CppClass* NoArgClass() {
+        #ifndef HAS_CODEGEN
         using arg_class = il2cpp_type_check::il2cpp_no_arg_class<T>;
-        if constexpr (has_get<arg_class>) {
-            return CRASH_UNLESS(arg_class::get());
-        } else if constexpr(ResultRequired) {
-            static_assert(false_t<il2cpp_type_check::il2cpp_no_arg_class<T>>,
-                "il2cpp-type-check.hpp could not deduce what C# type your type represents");
-        } else {
-            a_lack_of_no_arg_class_for<T>("please tell il2cpp-type-check.hpp what C# type your type represents");
-        }
-        return nullptr;
+        if constexpr (!has_get<arg_class>) {
+            if constexpr (ResultRequired) {
+                static_assert(false_t<arg_class>, "il2cpp-type-check.hpp could not deduce what C# type your type represents");
+            } else {
+                a_lack_of_no_arg_class_for<T>("please tell il2cpp-type-check.hpp what C# type your type represents");
+                return nullptr;
+            }
+        } else
+        #endif
+        return CRASH_UNLESS(il2cpp_type_check::il2cpp_no_arg_class<T>::get());
     }
 
     template<typename T>

--- a/src/utils/il2cpp-utils.cpp
+++ b/src/utils/il2cpp-utils.cpp
@@ -171,7 +171,7 @@ namespace il2cpp_utils {
             typeMap[il2cpp_functions::defaults->string_class] = "string";
             typeMap[il2cpp_functions::defaults->void_class] = "void";
         }
-        auto p = typeMap.find(il2cpp_functions::class_from_type(type));
+        auto p = typeMap.find(il2cpp_functions::class_from_il2cpp_type(type));
         if (p != typeMap.end()) {
             return p->second;
         } else {


### PR DESCRIPTION
Removed RTTI dependency (even for codegen) by having NestedTypes put their name as a static constexpr std::string_view.