### PR TITLE
Attempt to fix codegen static calls

### DIFF
--- a/shared/utils/il2cpp-utils-methods.hpp
+++ b/shared/utils/il2cpp-utils-methods.hpp
@@ -375,7 +375,7 @@ namespace il2cpp_utils {
     template<class TOut = void, bool checkTypes = true, class T, class... TArgs>
     requires (std::is_same_v<T, Il2CppClass*> || std::is_same_v<T, Il2CppType*> || std::is_same_v<T, std::nullptr_t>)
     TOut RunMethodThrow(T instance, const MethodInfo* method, TArgs&& ...params) {
-        return RunMethodThrow<TOut, checkTypes, T, TArgs...>(instance, method, std::forward<TArgs>(params)...);
+        return RunMethodThrow<TOut, checkTypes, T&, TArgs...>(instance, method, std::forward<TArgs>(params)...);
     }
     #else
     /// @brief Instantiates a generic MethodInfo* from the provided Il2CppClasses.


### PR DESCRIPTION
We deduced that this RunMethodThrow call was calling itself in an infinite loop, specifying we want it to call thet T& version should hopefully make it not have problems anymore