### PR TITLE
fix runmethodthrow infinite loop

### DIFF
--- a/shared/utils/il2cpp-utils-methods.hpp
+++ b/shared/utils/il2cpp-utils-methods.hpp
@@ -373,9 +373,9 @@ namespace il2cpp_utils {
         }
     }
     template<class TOut = void, bool checkTypes = true, class T, class... TArgs>
-    requires (std::is_same_v<T, Il2CppClass*> || std::is_same_v<T, Il2CppType*> || std::is_same_v<T, std::nullptr_t>)
+    requires ((std::is_same_v<T, Il2CppClass*> || std::is_same_v<T, Il2CppType*> || std::is_same_v<T, std::nullptr_t>) && std::is_same_v<std::remove_reference_t<T>, T>)
     TOut RunMethodThrow(T instance, const MethodInfo* method, TArgs&& ...params) {
-        return RunMethodThrow<TOut, checkTypes, T&, TArgs...>(instance, method, std::forward<TArgs>(params)...);
+        return RunMethodThrow<TOut, checkTypes, T, TArgs...>(instance, method, std::forward<TArgs>(params)...);
     }
     #else
     /// @brief Instantiates a generic MethodInfo* from the provided Il2CppClasses.

--- a/shared/utils/il2cpp-utils-methods.hpp
+++ b/shared/utils/il2cpp-utils-methods.hpp
@@ -373,7 +373,7 @@ namespace il2cpp_utils {
         }
     }
     template<class TOut = void, bool checkTypes = true, class T, class... TArgs>
-    requires ((std::is_same_v<T, Il2CppClass*> || std::is_same_v<T, Il2CppType*> || std::is_same_v<T, std::nullptr_t>) && std::is_same_v<std::remove_reference_t<T>, T>)
+    requires ((std::is_same_v<T, Il2CppClass*> || std::is_same_v<T, Il2CppType*> || std::is_same_v<T, std::nullptr_t>) && !std::is_reference_v<T>)
     TOut RunMethodThrow(T instance, const MethodInfo* method, TArgs&& ...params) {
         return RunMethodThrow<TOut, checkTypes, T, TArgs...>(instance, method, std::forward<TArgs>(params)...);
     }

--- a/shared/utils/il2cpp-utils-methods.hpp
+++ b/shared/utils/il2cpp-utils-methods.hpp
@@ -375,7 +375,7 @@ namespace il2cpp_utils {
     template<class TOut = void, bool checkTypes = true, class T, class... TArgs>
     requires (std::is_same_v<T, Il2CppClass*> || std::is_same_v<T, Il2CppType*> || std::is_same_v<T, std::nullptr_t>)
     TOut RunMethodThrow(T instance, const MethodInfo* method, TArgs&& ...params) {
-        return RunMethodThrow<TOut, checkTypes, T, TArgs...>(instance, method, std::forward<TArgs>(params)...);
+        return RunMethodThrow<TOut, checkTypes, T&, TArgs...>(instance, method, std::forward<TArgs>(params)...);
     }
     #else
     /// @brief Instantiates a generic MethodInfo* from the provided Il2CppClasses.


### PR DESCRIPTION
specifiying it can't be called using a reference should fix the issue of it infinite looping