### PR TITLE
Ensure correct string size for string operator

### DIFF
--- a/src/utils/typedefs-wrapper.cpp
+++ b/src/utils/typedefs-wrapper.cpp
@@ -3,6 +3,7 @@
 #include "../../shared/utils/il2cpp-functions.hpp"
 #include "../../shared/utils/typedefs.h"
 #include <locale>
+#include <string.h>
 
 std::unordered_map<void*, size_t> Counter::addrRefCount;
 std::shared_mutex Counter::mutex;
@@ -49,7 +50,7 @@ StringW::operator std::string() {
     std::string val;
     val.resize(inst->length * 2, '\0');
     il2cpp_utils::detail::convstr(inst->chars, val.data(), inst->length);
-    val.shrink_to_fit();
+    val.resize(strlen(val.data()), '\0');
     return val;
 }
 

--- a/src/utils/typedefs-wrapper.cpp
+++ b/src/utils/typedefs-wrapper.cpp
@@ -47,7 +47,7 @@ namespace detail {
 
 StringW::operator std::string() {
     std::string val;
-    val.resize(inst->length, '\0');
+    val.resize(inst->length * 2, '\0');
     il2cpp_utils::detail::convstr(inst->chars, val.data(), inst->length);
     val.shrink_to_fit();
     return val;

--- a/src/utils/typedefs-wrapper.cpp
+++ b/src/utils/typedefs-wrapper.cpp
@@ -3,7 +3,6 @@
 #include "../../shared/utils/il2cpp-functions.hpp"
 #include "../../shared/utils/typedefs.h"
 #include <locale>
-#include <string.h>
 
 std::unordered_map<void*, size_t> Counter::addrRefCount;
 std::shared_mutex Counter::mutex;
@@ -50,7 +49,7 @@ StringW::operator std::string() {
     std::string val;
     val.resize(inst->length, '\0');
     il2cpp_utils::detail::convstr(inst->chars, val.data(), inst->length);
-    val.resize(strlen(val.data()), '\0');
+    val.shrink_to_fit();
     return val;
 }
 

--- a/src/utils/typedefs-wrapper.cpp
+++ b/src/utils/typedefs-wrapper.cpp
@@ -3,6 +3,7 @@
 #include "../../shared/utils/il2cpp-functions.hpp"
 #include "../../shared/utils/typedefs.h"
 #include <locale>
+#include <string.h>
 
 std::unordered_map<void*, size_t> Counter::addrRefCount;
 std::shared_mutex Counter::mutex;
@@ -47,8 +48,9 @@ namespace detail {
 
 StringW::operator std::string() {
     std::string val;
-    val.reserve(inst->length);
+    val.resize(inst->length, '\0');
     il2cpp_utils::detail::convstr(inst->chars, val.data(), inst->length);
+    val.resize(strlen(val.data()), '\0');
     return val;
 }
 


### PR DESCRIPTION
This change ensures the correct sizes for operator std::string by way of str.size().
Before this change the size was always 0 causing issues with for example the starts_with() method.

using resize to change the string length ensures the string is the right size, and resizing afterwards ensures the string length is shrunk to fit whatever size it should actually be