### PR TITLE
Add operator StringW to ConstString

### DIFF
--- a/shared/utils/typedefs-string.hpp
+++ b/shared/utils/typedefs-string.hpp
@@ -97,7 +97,8 @@ struct StringW {
     StringW(T str) noexcept : inst(il2cpp_utils::detail::alloc_str(str)) {}
     constexpr StringW(void* ins) noexcept : inst(static_cast<Il2CppString*>(ins)) {}
     constexpr StringW(Il2CppString* ins) noexcept : inst(ins) {}
-    constexpr StringW(const ConstString& conststring) noexcept : inst(conststring) {}
+    template <int sz>
+    constexpr StringW(ConstString<sz>& conststring) noexcept : inst(conststring) {}
     constexpr StringW(std::nullptr_t npt) noexcept : inst(npt) {}
     constexpr StringW() noexcept : inst(nullptr) {}
 
@@ -118,7 +119,6 @@ struct StringW {
     private:
     Il2CppString* inst;
 };
-
 static_assert(sizeof(StringW) == sizeof(void*));
 DEFINE_IL2CPP_DEFAULT_TYPE(StringW, string);
 NEED_NO_BOX(StringW);

--- a/shared/utils/typedefs-string.hpp
+++ b/shared/utils/typedefs-string.hpp
@@ -24,6 +24,34 @@ namespace detail {
 }
 }
 
+struct StringW {
+    // Dynamically allocated string
+    template<class T>
+    requires (!std::is_convertible_v<T, Il2CppString*> && (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T>))
+    StringW(T str) noexcept : inst(il2cpp_utils::detail::alloc_str(str)) {}
+    constexpr StringW(void* ins) noexcept : inst(static_cast<Il2CppString*>(ins)) {}
+    constexpr StringW(Il2CppString* ins) noexcept : inst(ins) {}
+    constexpr StringW(std::nullptr_t npt) noexcept : inst(npt) {}
+    constexpr StringW() noexcept : inst(nullptr) {}
+
+    operator std::string();
+    constexpr void* convert() noexcept {
+        return inst;
+    }
+    constexpr operator Il2CppString*() noexcept {
+        return inst;
+    }
+    constexpr Il2CppString* operator->() noexcept {
+        return inst;
+    }
+    operator std::u16string();
+    operator std::wstring();
+    operator std::u16string_view();
+
+    private:
+    Il2CppString* inst;
+};
+
 // C# strings can only have 'int' max length.
 template<int sz>
 struct ConstString {
@@ -67,6 +95,9 @@ struct ConstString {
     constexpr Il2CppString* operator->() noexcept {
         return operator Il2CppString*();
     }
+    constexpr operator StringW() {
+        return operator Il2CppString*();
+    }
     operator std::string() {
         std::string val;
         val.reserve(sz);
@@ -90,33 +121,6 @@ struct ConstString {
     char16_t chars[sz + 1];
 };
 
-struct StringW {
-    // Dynamically allocated string
-    template<class T>
-    requires (!std::is_convertible_v<T, Il2CppString*> && (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T>))
-    StringW(T str) noexcept : inst(il2cpp_utils::detail::alloc_str(str)) {}
-    constexpr StringW(void* ins) noexcept : inst(static_cast<Il2CppString*>(ins)) {}
-    constexpr StringW(Il2CppString* ins) noexcept : inst(ins) {}
-    constexpr StringW(std::nullptr_t npt) noexcept : inst(npt) {}
-    constexpr StringW() noexcept : inst(nullptr) {}
-
-    operator std::string();
-    constexpr void* convert() noexcept {
-        return inst;
-    }
-    constexpr operator Il2CppString*() noexcept {
-        return inst;
-    }
-    constexpr Il2CppString* operator->() noexcept {
-        return inst;
-    }
-    operator std::u16string();
-    operator std::wstring();
-    operator std::u16string_view();
-
-    private:
-    Il2CppString* inst;
-};
 static_assert(sizeof(StringW) == sizeof(void*));
 DEFINE_IL2CPP_DEFAULT_TYPE(StringW, string);
 NEED_NO_BOX(StringW);

--- a/shared/utils/typedefs-string.hpp
+++ b/shared/utils/typedefs-string.hpp
@@ -98,7 +98,7 @@ struct StringW {
     constexpr StringW(void* ins) noexcept : inst(static_cast<Il2CppString*>(ins)) {}
     constexpr StringW(Il2CppString* ins) noexcept : inst(ins) {}
     template <int sz>
-    constexpr StringW(ConstString<sz>& conststring) noexcept : inst(conststring) {}
+    constexpr StringW(ConstString<sz> const& conststring) noexcept : inst(conststring) {}
     constexpr StringW(std::nullptr_t npt) noexcept : inst(npt) {}
     constexpr StringW() noexcept : inst(nullptr) {}
 

--- a/shared/utils/typedefs-string.hpp
+++ b/shared/utils/typedefs-string.hpp
@@ -24,34 +24,6 @@ namespace detail {
 }
 }
 
-struct StringW {
-    // Dynamically allocated string
-    template<class T>
-    requires (!std::is_convertible_v<T, Il2CppString*> && (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T>))
-    StringW(T str) noexcept : inst(il2cpp_utils::detail::alloc_str(str)) {}
-    constexpr StringW(void* ins) noexcept : inst(static_cast<Il2CppString*>(ins)) {}
-    constexpr StringW(Il2CppString* ins) noexcept : inst(ins) {}
-    constexpr StringW(std::nullptr_t npt) noexcept : inst(npt) {}
-    constexpr StringW() noexcept : inst(nullptr) {}
-
-    operator std::string();
-    constexpr void* convert() noexcept {
-        return inst;
-    }
-    constexpr operator Il2CppString*() noexcept {
-        return inst;
-    }
-    constexpr Il2CppString* operator->() noexcept {
-        return inst;
-    }
-    operator std::u16string();
-    operator std::wstring();
-    operator std::u16string_view();
-
-    private:
-    Il2CppString* inst;
-};
-
 // C# strings can only have 'int' max length.
 template<int sz>
 struct ConstString {
@@ -95,9 +67,6 @@ struct ConstString {
     constexpr Il2CppString* operator->() noexcept {
         return operator Il2CppString*();
     }
-    constexpr operator StringW() {
-        return operator Il2CppString*();
-    }
     operator std::string() {
         std::string val;
         val.reserve(sz);
@@ -119,6 +88,35 @@ struct ConstString {
     void* monitor;
     int length;
     char16_t chars[sz + 1];
+};
+
+struct StringW {
+    // Dynamically allocated string
+    template<class T>
+    requires (!std::is_convertible_v<T, Il2CppString*> && (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T>))
+    StringW(T str) noexcept : inst(il2cpp_utils::detail::alloc_str(str)) {}
+    constexpr StringW(void* ins) noexcept : inst(static_cast<Il2CppString*>(ins)) {}
+    constexpr StringW(Il2CppString* ins) noexcept : inst(ins) {}
+    constexpr StringW(const ConstString& conststring) noexcept : inst(conststring) {}
+    constexpr StringW(std::nullptr_t npt) noexcept : inst(npt) {}
+    constexpr StringW() noexcept : inst(nullptr) {}
+
+    operator std::string();
+    constexpr void* convert() noexcept {
+        return inst;
+    }
+    constexpr operator Il2CppString*() noexcept {
+        return inst;
+    }
+    constexpr Il2CppString* operator->() noexcept {
+        return inst;
+    }
+    operator std::u16string();
+    operator std::wstring();
+    operator std::u16string_view();
+
+    private:
+    Il2CppString* inst;
 };
 
 static_assert(sizeof(StringW) == sizeof(void*));

--- a/shared/utils/typedefs-string.hpp
+++ b/shared/utils/typedefs-string.hpp
@@ -98,7 +98,7 @@ struct StringW {
     constexpr StringW(void* ins) noexcept : inst(static_cast<Il2CppString*>(ins)) {}
     constexpr StringW(Il2CppString* ins) noexcept : inst(ins) {}
     template <int sz>
-    constexpr StringW(ConstString<sz> const& conststring) noexcept : inst(conststring) {}
+    constexpr StringW(ConstString<sz>& conststring) noexcept : inst(static_cast<Il2CppString*>(conststring)) {}
     constexpr StringW(std::nullptr_t npt) noexcept : inst(npt) {}
     constexpr StringW() noexcept : inst(nullptr) {}
 


### PR DESCRIPTION
This adds operator StringW to ConstString so that it can be passed into codegen methods.

the moving of StringW in the file to above ConstString is required so that it can be used in the operator on ConstString