### PR TITLE
Fix off by 1

### DIFF
--- a/src/utils/typedefs-wrapper.cpp
+++ b/src/utils/typedefs-wrapper.cpp
@@ -34,8 +34,7 @@ namespace detail {
         if (convOut != std::codecvt_base::ok) {
             throw convOut;
         }
-        *to_next = '\0';
-        return (std::size_t)(to_next - 1 - outp);
+        return (std::size_t)(to_next - outp);
     }
 
     Il2CppString* alloc_str(std::string_view str) {


### PR DESCRIPTION
std::string is by itself already null terminated, so no need to do that for it, (especially after the resize should fix that already)
also the -1 on the size was causing all strings to be short 1 value (#116)