### PR TITLE
Fix string creation, operator std::string, u16string strappend mishap

### DIFF
--- a/copy.ps1
+++ b/copy.ps1
@@ -1,4 +1,4 @@
 .\build.ps1
 
-& adb push ./build/libbeatsaber-hook_1_0_0.so /sdcard/Android/data/com.beatgames.beatsaber/files/libs/libbeatsaber-hook_1_0_0.so
+& adb push ./build/libbeatsaber-hook_1_2_3.so /sdcard/Android/data/com.beatgames.beatsaber/files/libs/libbeatsaber-hook_1_2_3.so
 Copy-Item -Force build/libbeatsaber-hook_1_0_0.so ../libbeatsaber-hook_1_0_0.so

--- a/shared/utils/typedefs-array.hpp
+++ b/shared/utils/typedefs-array.hpp
@@ -328,8 +328,8 @@ struct ArrayW {
     template<class U = Il2CppObject*>
     U GetEnumerator() {
         static auto* method = CRASH_UNLESS(il2cpp_utils::FindMethodUnsafe(
-            this, "System.Collections.Generic.IEnumerable`1.GetEnumerator", 0));
-        return il2cpp_utils::RunMethodRethrow<U, false>(this, method);
+            val, "System.Collections.Generic.IEnumerable`1.GetEnumerator", 0));
+        return il2cpp_utils::RunMethodRethrow<U, false>(val, method);
     }
     bool Contains(T item) {
         // TODO: find a better way around the existence of 2 methods with this name (the 2nd not being generic at all)
@@ -374,13 +374,25 @@ struct ArrayW {
         return val->values;
     }
     iterator end() {
-        return &val->values[Length()];
+        return val->values + Length();
+    }
+    auto rbegin() {
+        return std::reverse_iterator(val->values + Length());
+    }
+    auto rend() {
+        return std::reverse_iterator(val->values);
     }
     const_iterator begin() const {
         return val->values;
     }
     const_iterator end() const {
-        return &val->values[Length()];
+        return val->values + Length();
+    }
+    auto rbegin() const {
+        return std::reverse_iterator(val->values + Length());
+    }
+    auto rend() const {
+        return std::reverse_iterator(val->values);
     }
     explicit operator const Ptr() const {
         return val;
@@ -406,6 +418,72 @@ struct ArrayW {
     }
     operator bool() const noexcept {
         return val != nullptr;
+    }
+
+    template<typename D = T>
+    T First() {
+        if (Length() > 0)
+            return val->values[0];
+        else 
+            throw std::runtime_error("First called on empty array!");
+    }
+
+    template<typename D = T>
+    requires(std::is_default_constructible_v<T>)
+    T FirstOrDefault() {
+        if (Length() > 0)
+            return val->values[0];
+        else return {};
+    }
+
+    template<typename D = T>
+    T Last() {
+        if (Length() > 0)
+            return val->values[Length() - 1];
+        else 
+            throw std::runtime_error("Last called on empty array!");
+    }
+
+    template<typename D = T>
+    requires(std::is_default_constructible_v<T>)
+    T LastOrDefault() {
+        if (Length() > 0)
+            return val->values[Length() - 1];
+        else return {};
+    }
+
+    template<class Predicate>
+    T First(Predicate pred) {
+        for (iterator it = begin(); it != end(); it++) {
+            if (pred(*it)) return *it;
+        }
+        throw std::runtime_error("First on array found no value that matched predicate");
+    }
+
+    template<class Predicate>
+    requires(std::is_default_constructible_v<T>)
+    T FirstOrDefault(Predicate pred) {
+        for (iterator it = begin(); it != end(); it++) {
+            if (pred(*it)) return *it;
+        }
+        return {};
+    }
+
+    template<class Predicate>
+    T Last(Predicate pred) {
+        for (auto it = rbegin(); it != rend(); it++) {
+            if (pred(*it)) return *it;
+        }
+        throw std::runtime_error("Last on array found no value that matched predicate");
+    }
+
+    template<class Predicate>
+    requires(std::is_default_constructible_v<T>)
+    T LastOrDefault(Predicate pred) {
+        for (auto it = rbegin(); it != rend(); it++) {
+            if (pred(*it)) return *it;
+        }
+        return {};
     }
 
     constexpr void* convert() const noexcept {

--- a/shared/utils/typedefs-array.hpp
+++ b/shared/utils/typedefs-array.hpp
@@ -420,7 +420,6 @@ struct ArrayW {
         return val != nullptr;
     }
 
-    template<typename D = T>
     T First() {
         if (Length() > 0)
             return val->values[0];
@@ -436,7 +435,6 @@ struct ArrayW {
         else return {};
     }
 
-    template<typename D = T>
     T Last() {
         if (Length() > 0)
             return val->values[Length() - 1];

--- a/shared/utils/typedefs-string.hpp
+++ b/shared/utils/typedefs-string.hpp
@@ -168,7 +168,7 @@ struct StringW {
 
     template<typename T>
     requires (!std::is_constructible_v<T, StringW> && (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T>))
-    StringW& operator +=(T const rhs) noexcept {
+    StringW& operator +=(T const& rhs) noexcept {
         inst = il2cpp_utils::detail::strappend(inst, rhs);
         return *this;
     }
@@ -184,13 +184,13 @@ struct StringW {
 
     template<typename T>
     requires (!std::is_constructible_v<T, StringW> && (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T>))
-    StringW operator +(T const rhs) const noexcept {
+    StringW operator +(T const& rhs) const noexcept {
         return il2cpp_utils::detail::strappend(inst, rhs);
     }
 
     template<typename T>
     requires (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T> || std::is_same_v<T, StringW>)
-    bool operator <(T const rhs) const noexcept {
+    bool operator <(T const& rhs) const noexcept {
         if constexpr (std::is_same_v<T, StringW>) return il2cpp_utils::detail::strless(inst, rhs.inst);
         else return il2cpp_utils::detail::strless(inst, rhs);
     }
@@ -209,14 +209,14 @@ struct StringW {
 
     template<typename T>
     requires (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T> || std::is_same_v<T, StringW>)
-    bool starts_with(T const rhs) const noexcept {
+    bool starts_with(T const& rhs) const noexcept {
         if constexpr (std::is_same_v<T, StringW>) return il2cpp_utils::detail::strstart(inst, rhs.inst);
         else return il2cpp_utils::detail::strstart(inst, rhs);
     }
     
     template<typename T>
     requires (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T> || std::is_same_v<T, StringW>)
-    bool ends_with(T const rhs) const noexcept {
+    bool ends_with(T const& rhs) const noexcept {
         if constexpr (std::is_same_v<T, StringW>) return il2cpp_utils::detail::strend(inst, rhs.inst);
         else return il2cpp_utils::detail::strend(inst, rhs);
     }

--- a/shared/utils/typedefs-string.hpp
+++ b/shared/utils/typedefs-string.hpp
@@ -32,12 +32,18 @@ namespace detail {
     bool strcomp(Il2CppString const* lhs, std::string_view const rhs) noexcept;
     bool strcomp(Il2CppString const* lhs, std::u16string_view const rhs) noexcept;
     bool strcomp(Il2CppString const* lhs, Il2CppString const* rhs) noexcept;
+
     bool strless(Il2CppString const* lhs, std::string_view const rhs) noexcept;
     bool strless(Il2CppString const* lhs, std::u16string_view const rhs) noexcept;
+    bool strless(Il2CppString const* lhs, Il2CppString const* rhs) noexcept;
+    
     bool strstart(Il2CppString const* lhs, std::string_view const rhs) noexcept;
     bool strstart(Il2CppString const* lhs, std::u16string_view const rhs) noexcept;
+    bool strstart(Il2CppString const* lhs, Il2CppString const* rhs) noexcept;
+
     bool strend(Il2CppString const* lhs, std::string_view const rhs) noexcept;
     bool strend(Il2CppString const* lhs, std::u16string_view const rhs) noexcept;
+    bool strend(Il2CppString const* lhs, Il2CppString const* rhs) noexcept;
 }
 }
 
@@ -182,11 +188,11 @@ struct StringW {
         return il2cpp_utils::detail::strappend(inst, rhs);
     }
 
-    bool operator <(StringW const& rhs) const noexcept;
     template<typename T>
-    requires (!std::is_constructible_v<T, StringW> && (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T>))
+    requires (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T> || std::is_same_v<T, StringW>)
     bool operator <(T const rhs) const noexcept {
-        return il2cpp_utils::detail::strless(inst, rhs);
+        if constexpr (std::is_same_v<T, StringW>) return il2cpp_utils::detail::strless(inst, rhs.inst);
+        else return il2cpp_utils::detail::strless(inst, rhs);
     }
 
     template<int sz>
@@ -194,25 +200,25 @@ struct StringW {
         return il2cpp_utils::detail::strcomp(inst, rhs.operator Il2CppString const*());
     }
     
-    bool operator ==(StringW const& rhs) const noexcept;
     template<typename T>
-    requires (!std::is_constructible_v<T, StringW> && (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T>))
-    bool operator ==(T const rhs) const noexcept {
-        return il2cpp_utils::detail::strcomp(inst, rhs);
+    requires (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T> || std::is_same_v<T, StringW>)
+    bool operator ==(T const& rhs) const noexcept {
+        if constexpr (std::is_same_v<T, StringW>) return il2cpp_utils::detail::strcomp(inst, rhs.inst);
+        else return il2cpp_utils::detail::strcomp(inst, rhs);
     }
 
-    bool starts_with(StringW const& rhs) const noexcept;
     template<typename T>
-    requires (!std::is_constructible_v<T, StringW> && (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T>))
+    requires (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T> || std::is_same_v<T, StringW>)
     bool starts_with(T const rhs) const noexcept {
-        return il2cpp_utils::detail::strstart(inst, rhs);
+        if constexpr (std::is_same_v<T, StringW>) return il2cpp_utils::detail::strstart(inst, rhs.inst);
+        else return il2cpp_utils::detail::strstart(inst, rhs);
     }
     
-    bool ends_with(StringW const& rhs) const noexcept;
     template<typename T>
-    requires (!std::is_constructible_v<T, StringW> && (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T>))
+    requires (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T> || std::is_same_v<T, StringW>)
     bool ends_with(T const rhs) const noexcept {
-        return il2cpp_utils::detail::strend(inst, rhs);
+        if constexpr (std::is_same_v<T, StringW>) return il2cpp_utils::detail::strend(inst, rhs.inst);
+        else return il2cpp_utils::detail::strend(inst, rhs);
     }
     
     using iterator = Il2CppChar*;

--- a/shared/utils/typedefs-string.hpp
+++ b/shared/utils/typedefs-string.hpp
@@ -167,25 +167,18 @@ struct StringW {
     }
 
     template<typename T>
-    requires (!std::is_constructible_v<T, StringW> && (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T>))
+    requires (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T> || std::is_same_v<T, StringW>)
     StringW& operator +=(T const& rhs) noexcept {
-        inst = il2cpp_utils::detail::strappend(inst, rhs);
+        if constexpr (std::is_same_v<T, StringW>) inst = il2cpp_utils::detail::strappend(inst, rhs.inst);
+        else inst = il2cpp_utils::detail::strappend(inst, rhs);
         return *this;
-    }
-
-    StringW& operator +=(StringW const& rhs) noexcept {
-        inst = il2cpp_utils::detail::strappend(inst, rhs.inst);
-        return *this;
-    }
-
-    StringW operator +(StringW const& rhs) const noexcept {
-        return il2cpp_utils::detail::strappend(inst, rhs.inst);
     }
 
     template<typename T>
-    requires (!std::is_constructible_v<T, StringW> && (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T>))
+    requires (std::is_constructible_v<std::u16string_view, T> || std::is_constructible_v<std::string_view, T> || std::is_same_v<T, StringW>)
     StringW operator +(T const& rhs) const noexcept {
-        return il2cpp_utils::detail::strappend(inst, rhs);
+        if constexpr (std::is_same_v<T, StringW>) return il2cpp_utils::detail::strappend(inst, rhs.inst);
+        else return il2cpp_utils::detail::strappend(inst, rhs);
     }
 
     template<typename T>

--- a/src/tests/array-wrapper-tests.cpp
+++ b/src/tests/array-wrapper-tests.cpp
@@ -41,6 +41,18 @@ static void doThing() {
     std::cout << i << std::endl;
     // Should be simply nullptr
     std::cout << static_cast<Array<float>*>(initThing) << std::endl;
+    
+    /// get first element that fulfills the predicate
+    arr.FirstOrDefault();
+    arr3.First();
+    arr.FirstOrDefault([](auto x){ return x == 0; });
+    arr3.First([](auto x){ return x == 0; });
+ 
+    /// get first reverse iter element that fulfills the predicate
+    arr.FirstOrDefault();
+    arr3.First();
+    arr.LastOrDefault([](auto x){ return x == 0; });
+    arr3.Last([](auto x){ return x == 0; });
 }
 
 #include "../../shared/utils/il2cpp-utils.hpp"

--- a/src/utils/typedefs-wrapper.cpp
+++ b/src/utils/typedefs-wrapper.cpp
@@ -279,7 +279,7 @@ namespace detail {
 }
 
 StringW::operator std::string() const {
-    std::string val(inst->length * 8 + 1, '\0');
+    std::string val(inst->length * 4 + 1, '\0');
     auto resSize = il2cpp_utils::detail::convstr(inst->chars, val.data(), inst->length, val.size());
     val.resize(resSize);
     return val;

--- a/src/utils/typedefs-wrapper.cpp
+++ b/src/utils/typedefs-wrapper.cpp
@@ -348,7 +348,7 @@ namespace detail {
 }
 
 StringW::operator std::string() const {
-    std::string val(inst->length * 4 + 1, '\0');
+    std::string val(inst->length * sizeof(wchar_t) + 1, '\0');
     auto resSize = il2cpp_utils::detail::convstr(inst->chars, val.data(), inst->length, val.size());
     val.resize(resSize);
     return val;

--- a/src/utils/typedefs-wrapper.cpp
+++ b/src/utils/typedefs-wrapper.cpp
@@ -46,6 +46,11 @@ namespace detail {
         return il2cpp_functions::string_new_utf16((Il2CppChar const*) str.data(), str.size());
     }
 
+    Il2CppString* CreateString(int length) {
+        static MethodInfo const* methodInfo = il2cpp_utils::FindMethod(classof(Il2CppString*), "CreateString", std::vector<Il2CppType const*>{ il2cpp_utils::ExtractIndependentType<Il2CppChar>(), il2cpp_utils::ExtractIndependentType<int>()});
+        return CRASH_UNLESS(il2cpp_utils::RunStaticMethodUnsafe<Il2CppString*>(methodInfo, Il2CppChar('\0'), length));
+    }
+
     Il2CppString* strappend(Il2CppString const* lhs, Il2CppString const* rhs) noexcept {
         if (!lhs && !rhs) return nullptr;
 
@@ -57,7 +62,7 @@ namespace detail {
         else
         {
             size_t fullLength = lhs->length + rhs->length;
-            Il2CppString* result = CRASH_UNLESS(il2cpp_utils::NewUnsafe<Il2CppString*>(classof(Il2CppString*), Il2CppChar('\0'), fullLength));
+            Il2CppString* result = CreateString(fullLength);
             memcpy(result->chars, lhs->chars, lhs->length * sizeof(Il2CppChar));
             Il2CppChar* pastFirstString = result->chars + lhs->length;
             memcpy(pastFirstString, rhs->chars, rhs->length * sizeof(*rhs->chars));
@@ -69,7 +74,7 @@ namespace detail {
         if (lhs)
         {
             int fullLength = lhs->length + rhs.size();
-            Il2CppString* result = CRASH_UNLESS(il2cpp_utils::NewUnsafe<Il2CppString*>(classof(Il2CppString*), Il2CppChar('\0'), fullLength));
+            Il2CppString* result = CreateString(fullLength);
             memcpy(result->chars, lhs->chars, lhs->length * sizeof(Il2CppChar));
             Il2CppChar* pastFirstString = result->chars + lhs->length;
             static_assert(sizeof(*pastFirstString) == sizeof(*rhs.data()));
@@ -86,7 +91,7 @@ namespace detail {
         if (lhs)
         {
             int fullLength = lhs->length + rhs.size();
-            Il2CppString* result = CRASH_UNLESS(il2cpp_utils::NewUnsafe<Il2CppString*>(classof(Il2CppString*), Il2CppChar('\0'), fullLength));
+            Il2CppString* result = CreateString(fullLength);
             memcpy(result->chars, lhs->chars, lhs->length * sizeof(Il2CppChar));
             Il2CppChar* pastFirstString = result->chars + lhs->length;
             convstr(rhs.data(), pastFirstString, rhs.size());
@@ -102,7 +107,7 @@ namespace detail {
         if (rhs)
         {
             int fullLength = rhs->length + lhs.size();
-            Il2CppString* result = CRASH_UNLESS(il2cpp_utils::NewUnsafe<Il2CppString*>(classof(Il2CppString*), Il2CppChar('\0'), fullLength));
+            Il2CppString* result = CreateString(fullLength);
             convstr(lhs.data(), result->chars, lhs.size());
             Il2CppChar* pastFirstString = result->chars + lhs.size();
             memcpy(pastFirstString, rhs->chars, rhs->length * sizeof(*pastFirstString));
@@ -118,10 +123,10 @@ namespace detail {
         if (rhs)
         {
             int fullLength = rhs->length + lhs.size();
-            Il2CppString* result = CRASH_UNLESS(il2cpp_utils::NewUnsafe<Il2CppString*>(classof(Il2CppString*), Il2CppChar('\0'), fullLength));
+            Il2CppString* result = CreateString(fullLength);
             static_assert(sizeof(Il2CppChar) == sizeof(*lhs.data()));
             memcpy(result->chars, lhs.data(), lhs.size() * sizeof(*lhs.data()));
-            Il2CppChar* pastFirstString = result->chars + rhs->length;
+            Il2CppChar* pastFirstString = result->chars + lhs.size();
             memcpy(pastFirstString, rhs->chars, rhs->length * sizeof(*pastFirstString));
             return result;
         }
@@ -274,7 +279,7 @@ namespace detail {
 }
 
 StringW::operator std::string() const {
-    std::string val(inst->length * 2 + 1, '\0');
+    std::string val(inst->length * 8 + 1, '\0');
     auto resSize = il2cpp_utils::detail::convstr(inst->chars, val.data(), inst->length, val.size());
     val.resize(resSize);
     return val;


### PR DESCRIPTION
 - Fixed String creation, moved into it's own method
 - Fixed operator std::string not allocating enough space upfront
 - fixed a mistake in calciulating the pastFirstString value in strappend(u16string_view, Il2CppString*)