### PR TITLE
SafePtrUnity untested

### DIFF
--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -377,11 +377,11 @@ struct SafePtr {
     } 
 
     T* ptr() {
-        return __SAFE_PTR_NULL_HANDLE_CHECK(internalHandle, internalHandle->instancePointer);
+        __SAFE_PTR_NULL_HANDLE_CHECK(internalHandle, internalHandle->instancePointer);
     }
 
     T const* ptr() const{
-        return __SAFE_PTR_NULL_HANDLE_CHECK(internalHandle, internalHandle->instancePointer);
+        __SAFE_PTR_NULL_HANDLE_CHECK(internalHandle, internalHandle->instancePointer);
     }
 
     /// @brief Returns false if this is a defaultly constructed SafePtr, true otherwise.

--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -523,7 +523,7 @@ struct SafePtrUnity : public SafePtr<T, true> {
 
     inline bool isAlive() {
 #ifdef HAS_CODEGEN
-        return ((bool)Parent::internalHandle) && (Parent::ptr()) && Parent::ptr()->m_cachedPtr.m_value;
+        return ((bool)Parent::internalHandle) && (Parent::ptr()) && Parent::ptr()->m_CachedPtr.m_value;
 #else
         // offset yay
         // the offset as specified in the codegen header of [m_cachedPtr] is 0x10

--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -507,7 +507,7 @@ struct SafePtrUnity : public SafePtr<T, true> {
             return other.isAlive() == isAlive();
         }
 
-        return static_cast<T*>(other.internalHandle) == static_cast<T*>(ptr());
+        return static_cast<T*>(other.internalHandle) == static_cast<T*>(Parent::ptr());
     }
 
     template<typename U = T>
@@ -516,19 +516,19 @@ struct SafePtrUnity : public SafePtr<T, true> {
             return static_cast<bool>(other) == isAlive();
         }
 
-        return static_cast<T*>(other) == static_cast<T*>(ptr());
+        return static_cast<T*>(other) == static_cast<T*>(Parent::ptr());
     }
 
 
 
     inline bool isAlive() {
 #ifdef HAS_CODEGEN
-        return ((bool)Parent::internalHandle) && (ptr()) && ptr().m_cachedPtr.m_value;
+        return ((bool)Parent::internalHandle) && (Parent::ptr()) && Parent::ptr().m_cachedPtr.m_value;
 #else
         // offset yay
         // the offset as specified in the codegen header of [m_cachedPtr] is 0x10
         // which is also the first field of the instance UnityEngine.Object
-      return ((bool)Parent::internalHandle) && (ptr()) && *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(ptr()) + 0x10);
+      return ((bool)Parent::internalHandle) && (Parent::ptr()) && *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(Parent::ptr()) + 0x10);
 #endif
     }
 

--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -222,18 +222,12 @@ private:
 // TODO: Remove all conversion operators? (Basically force people to guarantee lifetime of held instance?)
 
 #ifdef HAS_CODEGEN
-
 namespace UnityEngine {
     class Object;
 }
-
-template <typename T>
-requires(std::is_assignable_v<UnityEngine::Object, T>)
-struct SafePtrUnity;
-#else
-template <typename T>
-struct SafePtrUnity;
 #endif
+template <typename T>
+struct SafePtrUnity;
 
 /// @brief Represents a C++ type that wraps a C# pointer that will be valid for the entire lifetime of this instance.
 /// This instance must be created at a time such that il2cpp_functions::Init is valid, or else it will throw a CreatedTooEarlyException

--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -513,7 +513,7 @@ struct SafePtrUnity : public SafePtr<T, true> {
         // offset yay
         // the offset as specified in the codegen header of [m_cachedPtr] is 0x10
         // which is also the first field of the instance UnityEngine.Object
-      return ((bool)Parent::internalHandle) && (static_cast<T*>(Parent::internalHandle)) && *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(Parent::internalHandle) + 0x10));
+      return ((bool)Parent::internalHandle) && (static_cast<T*>(Parent::internalHandle)) && *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(Parent::internalHandle) + 0x10);
 #endif
     }
 

--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -523,7 +523,7 @@ struct SafePtrUnity : public SafePtr<T, true> {
 
     inline bool isAlive() {
 #ifdef HAS_CODEGEN
-        return ((bool)Parent::internalHandle) && (Parent::ptr()) && Parent::ptr().m_cachedPtr.m_value;
+        return ((bool)Parent::internalHandle) && (Parent::ptr()) && Parent::ptr()->m_cachedPtr.m_value;
 #else
         // offset yay
         // the offset as specified in the codegen header of [m_cachedPtr] is 0x10

--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -372,6 +372,21 @@ struct SafePtr {
     /// @brief Returns false if this is a defaultly constructed SafePtr, true otherwise.
     /// Note that this means that it will return true if it holds a nullptr value explicitly!
     /// This means that you should check yourself before calling anything using the held T*.
+    inline bool isHandleValid() const {
+        return (bool) internalHandle;
+    } 
+
+    T* ptr() {
+        return __SAFE_PTR_NULL_HANDLE_CHECK(internalHandle, internalHandle->instancePointer);
+    }
+
+    T const* ptr() const{
+        return __SAFE_PTR_NULL_HANDLE_CHECK(internalHandle, internalHandle->instancePointer);
+    }
+
+    /// @brief Returns false if this is a defaultly constructed SafePtr, true otherwise.
+    /// Note that this means that it will return true if it holds a nullptr value explicitly!
+    /// This means that you should check yourself before calling anything using the held T*.
     operator bool() const noexcept {
         return (bool)internalHandle;
     }
@@ -398,7 +413,7 @@ struct SafePtr {
     }
 
 private:
-    friend class SafePtrUnity<T>;
+    friend struct SafePtrUnity<T>;
 
     struct SafePointerWrapper {
         static SafePointerWrapper* New(T* instance) {

--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -484,12 +484,12 @@ struct SafePtrUnity : public SafePtr<T, true> {
     }
 
     inline SafePtrUnity<T>& operator=(T* other) {
-        emplace(other);
+        Parent::emplace(other);
         return *this;
     }
 
     inline SafePtrUnity<T>& operator=(T& other) {
-        emplace(other);
+        Parent::emplace(other);
         return *this;
     }
 

--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -511,7 +511,7 @@ struct SafePtrUnity : public SafePtr<T, true> {
         return ((bool)Parent::internalHandle) && (static_cast<T*>(Parent::internalHandle)) && Parent::internalHandle.m_cachedPtr.m_value;
 #else
         // offset yay
-      return ((bool)Parent::internalHandle) && (static_cast<T*>(Parent::internalHandle)) && (Parent::internalHandle + 0x10)
+      return ((bool)Parent::internalHandle) && (static_cast<T*>(Parent::internalHandle)) && (Parent::internalHandle + 0x10);
 #endif
     }
 

--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -481,12 +481,37 @@ struct SafePtrUnity : public SafePtr<T, true> {
         __SAFE_PTR_UNITY_NULL_HANDLE_CHECK(*Parent::internalHandle->instancePointer);
     }
 
+    operator bool() const {
+        return isAlive();
+    }
+
+    template<typename U = T>
+    requires(std::is_assignable_v<T, U> || std::is_same_v<T, U>)
+    bool operator ==(SafePtrUnity<U> const& other) const {
+        if (!other.isAlive() || !isAlive()) {
+            return other.isAlive() == isAlive();
+        }
+
+        return static_cast<T*>(other.internalHandle) == static_cast<T*>(Parent::internalHandle);
+    }
+
+    template<typename U = T>
+    bool operator ==(U const* other) const {
+        if (!other || !isAlive()) {
+            return static_cast<bool>(other) == isAlive();
+        }
+
+        return static_cast<T*>(other) == static_cast<T*>(Parent::internalHandle);
+    }
+
+
+
     inline bool isAlive() {
 #ifdef HAS_CODEGEN
-        return Parent::internalHandle && Parent::internalHandle.m_cachedPtr.m_value;
+        return ((bool)Parent::internalHandle) && (static_cast<T*>(Parent::internalHandle)) && Parent::internalHandle.m_cachedPtr.m_value;
 #else
         // offset yay
-      return Parent::internalHandle && (Parent::internalHandle + 0x10)
+      return ((bool)Parent::internalHandle) && (static_cast<T*>(Parent::internalHandle)) && (Parent::internalHandle + 0x10)
 #endif
     }
 

--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -507,7 +507,7 @@ struct SafePtrUnity : public SafePtr<T, true> {
             return other.isAlive() == isAlive();
         }
 
-        return static_cast<T*>(other.internalHandle) == static_cast<T*>(Parent::internalHandle);
+        return static_cast<T*>(other.internalHandle) == static_cast<T*>(ptr());
     }
 
     template<typename U = T>
@@ -516,19 +516,19 @@ struct SafePtrUnity : public SafePtr<T, true> {
             return static_cast<bool>(other) == isAlive();
         }
 
-        return static_cast<T*>(other) == static_cast<T*>(Parent::internalHandle);
+        return static_cast<T*>(other) == static_cast<T*>(ptr());
     }
 
 
 
     inline bool isAlive() {
 #ifdef HAS_CODEGEN
-        return ((bool)Parent::internalHandle) && (static_cast<T*>(Parent::internalHandle)) && Parent::internalHandle.m_cachedPtr.m_value;
+        return ((bool)Parent::internalHandle) && (ptr()) && ptr().m_cachedPtr.m_value;
 #else
         // offset yay
         // the offset as specified in the codegen header of [m_cachedPtr] is 0x10
         // which is also the first field of the instance UnityEngine.Object
-      return ((bool)Parent::internalHandle) && (static_cast<T*>(Parent::internalHandle)) && *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(Parent::internalHandle) + 0x10);
+      return ((bool)Parent::internalHandle) && (ptr()) && *reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(ptr()) + 0x10);
 #endif
     }
 

--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -483,6 +483,16 @@ struct SafePtrUnity : public SafePtr<T, true> {
         __SAFE_PTR_UNITY_NULL_HANDLE_CHECK(Parent::internalHandle->instancePointer);
     }
 
+    inline SafePtrUnity<T>& operator=(T* other) {
+        emplace(other);
+        return *this;
+    }
+
+    inline SafePtrUnity<T>& operator=(T& other) {
+        emplace(other);
+        return *this;
+    }
+
     /// @brief Explicitly cast this instance to a T*.
     /// Note, however, that the lifetime of this returned T* is not longer than the lifetime of this instance.
     /// Consider passing a SafePtrUnity reference or copy instead.

--- a/src/tests/safeptr-tests.cpp
+++ b/src/tests/safeptr-tests.cpp
@@ -86,5 +86,28 @@ static void test_cast() {
             SAFE_ABORT();
         }
     }
+    {
+        Il2CppObject inst;
+        SafePtrUnity<Il2CppObject> a(&inst);
+        // Standard operations should apply just fine for an Il2CppObject--
+        // we are casting to grab an invalid field, so this won't ever work in practice, but
+        // it should compile
+        auto b = a.cast<Il2CppReflectionType>();
+        auto c = *a.try_cast<Il2CppReflectionType>();
+        if (a) {
+            CRASH_UNLESS(static_cast<Il2CppObject*>(a));
+        }
+        if (b) {
+            CRASH_UNLESS(static_cast<Il2CppReflectionType*>(b));
+        }
+        auto call_ref = [](Il2CppObject&) {};
+        call_ref(*a);
+        SafePtrUnity<Il2CppObject> const ca(a);
+        auto call_cref = [](Il2CppObject const&) {};
+        // Should not compile:
+        // Il2CppObject& v = ca;
+        call_cref(*ca);
+        call_cref(*a);
+    }
 }
 #endif


### PR DESCRIPTION
This is intended to make Unity objects safer outside of the il2cpp realm. 
It does have some slight behaviour changes compared to SafePtr:
- operator bool() returns false if the internal handle is `nullptr`
- Shows errors if the type isn't assignable in codegen (perhapps allow `Il2CppObject`?)