### PR TITLE
Improvement PR

### DIFF
--- a/shared/utils/accessor-wrapper-types.hpp
+++ b/shared/utils/accessor-wrapper-types.hpp
@@ -63,7 +63,6 @@ namespace bs_hook {
     // We cannot EASILY solve this using wrapper types, because we could be holding a value type as T.
     // This makes things tricky and we should come back to this when we are confident we can handle this case correctly.
 
-
     template<internal::NTTPString name, class T, bool get, bool set>
     /// @brief Represents a InstanceProperty on a wrapper type. Forwards to calling the get/set methods where applicable.
     struct InstanceProperty;
@@ -89,6 +88,9 @@ namespace bs_hook {
             return this->operator T();
         }
 
+        template<typename... Targs>
+        decltype(auto) operator ()(Targs&&... args) { return this->operator T()(std::forward<Targs...>(args...)); }
+
         private:
         void* instance;
     };
@@ -102,6 +104,7 @@ namespace bs_hook {
             if (!res) throw PropertyException(std::string("Failed to set instance property: ") + name.data.data());
             return *this;
         }
+        
         private:
         void* instance;
     };
@@ -139,6 +142,14 @@ auto& operator op##=(const U& rhs) {        \
         inline auto v() const {
             return this->operator T();
         }
+
+        template<typename... Targs>
+        decltype(auto) operator ()(Targs&&... args) { return this->operator T()(std::forward<Targs...>(args...)); }
+
+        auto& operator ++() { return this->operator=(++this->operator T()); }
+        auto& operator ++(int) { return this->operator=(this->operator T()++); }
+        auto& operator --() { return this->operator=(--this->operator T()); }
+        auto& operator --(int) { return this->operator=(this->operator T()--); }
 
         /* These operators forward to the ones on the underlying type */
         BINARY_OPERATOR_OP_EQ_PROP(+);
@@ -181,6 +192,9 @@ auto& operator op##=(const U& rhs) {        \
         inline auto v() const {
             return this->operator T();
         }
+
+        template<typename... Targs>
+        decltype(auto) operator ()(Targs&&... args) { return this->operator T()(std::forward<Targs...>(args...)); }
     };
 
     template<class T, internal::NTTPString name, auto klass_resolver>
@@ -223,6 +237,14 @@ auto& operator op##=(const U& rhs) {        \
         inline auto v() const {
             return this->operator T();
         }
+
+        template<typename... Targs>
+        decltype(auto) operator ()(Targs&&... args) { return this->operator T()(std::forward<Targs...>(args...)); }
+
+        auto& operator ++() { return this->operator=(++this->operator T()); }
+        auto& operator ++(int) { return this->operator=(this->operator T()++); }
+        auto& operator --() { return this->operator=(--this->operator T()); }
+        auto& operator --(int) { return this->operator=(this->operator T()--); }
 
         BINARY_OPERATOR_OP_EQ_PROP(+);
         BINARY_OPERATOR_OP_EQ_PROP(-);
@@ -275,6 +297,9 @@ auto& operator op##=(const U& rhs) {        \
             return this->operator Ref();
         }
 
+        template<typename... Targs>
+        decltype(auto) operator ()(Targs&&... args) { return this->operator Ref()(std::forward<Targs...>(args...)); }
+
         private:
         void* instance;
     };
@@ -306,6 +331,11 @@ auto& operator op##=(const U& rhs) {        \
             }
             return *this;
         }
+
+        auto& operator ++() { return this->operator=(++this->operator Ref()); }
+        auto& operator ++(int) { return this->operator=(this->operator Ref()++); }
+        auto& operator --() { return this->operator=(--this->operator Ref()); }
+        auto& operator --(int) { return this->operator=(this->operator Ref()--); }
 
         BINARY_OPERATOR_OP_EQ_FIELD(+);
         BINARY_OPERATOR_OP_EQ_FIELD(-);
@@ -355,6 +385,9 @@ auto& operator op##=(const U& rhs) {            \
         inline auto v() const {
             return this->operator T();
         }
+
+        template<typename... Targs>
+        decltype(auto) operator ()(Targs&&... args) { return this->operator T()(std::forward<Targs...>(args...)); }
     };
 
     template<class T, internal::NTTPString name, auto klass_resolver>
@@ -366,6 +399,11 @@ auto& operator op##=(const U& rhs) {            \
             if (!val) throw FieldException(std::string("Could not set static field with name: ") + name.data.data());
             return *this;
         }
+
+        auto& operator ++() { return this->operator=(++this->operator T()); }
+        auto& operator ++(int) { return this->operator=(this->operator T()++); }
+        auto& operator --() { return this->operator=(--this->operator T()); }
+        auto& operator --(int) { return this->operator=(this->operator T()--); }
 
         BINARY_OPERATOR_OP_EQ_STATIC_FIELD(+);
         BINARY_OPERATOR_OP_EQ_STATIC_FIELD(-);

--- a/shared/utils/accessor-wrapper-types.hpp
+++ b/shared/utils/accessor-wrapper-types.hpp
@@ -44,7 +44,7 @@ namespace bs_hook {
     
     template<internal::NTTPString name, class T>
     struct InstanceProperty<name, T, true, false> {
-        explicit InstanceProperty(void* inst) noexcept : instance(inst) {}
+        explicit constexpr InstanceProperty(void* inst) noexcept : instance(inst) {}
         operator T() const {
             auto res = il2cpp_utils::GetPropertyValue<T, false>(reinterpret_cast<Il2CppObject*>(const_cast<void*>(instance)), name.data.data());
             if (!res) throw PropertyException(std::string("Failed to get instance property: ") + name.data.data());
@@ -56,7 +56,7 @@ namespace bs_hook {
 
     template<internal::NTTPString name, class T>
     struct InstanceProperty<name, T, false, true> {
-        explicit InstanceProperty(void* inst) noexcept : instance(inst) {}
+        explicit constexpr InstanceProperty(void* inst) noexcept : instance(inst) {}
         InstanceProperty& operator=(T&& t) {
             auto val = reinterpret_cast<Il2CppObject*>(instance);
             auto res = il2cpp_utils::SetPropertyValue<false>(val, name.data.data(), std::forward<decltype(t)>(t));
@@ -69,7 +69,7 @@ namespace bs_hook {
 
     template<internal::NTTPString name, class T>
     struct InstanceProperty<name, T, true, true> {
-        explicit InstanceProperty(void* inst) noexcept : instance(inst) {}
+        explicit constexpr InstanceProperty(void* inst) noexcept : instance(inst) {}
         operator T() const {
             auto res = il2cpp_utils::GetPropertyValue<T, false>(reinterpret_cast<Il2CppObject*>(const_cast<void*>(instance)), name.data.data());
             if (!res) throw PropertyException(std::string("Failed to get instance property: ") + name.data.data());
@@ -133,7 +133,7 @@ namespace bs_hook {
     
     template<class T, std::size_t offset>
     struct InstanceField<T, offset, true> {
-        explicit InstanceField(void* inst) noexcept : instance(inst) {}
+        explicit constexpr InstanceField(void* inst) noexcept : instance(inst) {}
         operator T() const {
             if (instance == nullptr) throw NullException("Instance field access failed at offset: " + std::to_string(offset) + " because instance was null!");
             // No wbarrier required for unilateral gets
@@ -166,7 +166,7 @@ namespace bs_hook {
 
     template<class T, std::size_t offset>
     struct InstanceField<T, offset, false> {
-        explicit InstanceField(void* inst) noexcept : instance(inst) {}
+        explicit constexpr InstanceField(void* inst) noexcept : instance(inst) {}
         operator T() const {
             if (instance == nullptr) throw NullException("Instance field access failed at offset: " + std::to_string(offset) + " because instance was null!");
             // TODO: Also set wbarrier

--- a/shared/utils/accessor-wrapper-types.hpp
+++ b/shared/utils/accessor-wrapper-types.hpp
@@ -19,6 +19,32 @@ namespace bs_hook {
             }
             std::array<char, sz> data;
         };
+
+        /* Anything that's not a wrapper type */
+        template<typename T, bool is_const>
+        struct MakeWrapperPtr {
+            using type = std::conditional_t<is_const, std::add_pointer_t<std::add_const_t<T>>, std::add_pointer_t<T>>;
+        };
+
+        /* Wrapper Types */
+        template<typename T, bool is_const>
+        requires(il2cpp_utils::has_il2cpp_conversion<T>)
+        struct MakeWrapperPtr<T, is_const> {
+            using type = T;
+        };
+
+        /* Anything that's not a wrapper type */
+        template<typename T, bool is_const> 
+        struct MakeWrapperRef {
+            using type = std::conditional_t<is_const, T const&, T&>;
+        };
+
+        /* Wrapper Types */
+        template<typename T, bool is_const> 
+        requires(il2cpp_utils::has_il2cpp_conversion<T>)
+        struct MakeWrapperRef<T, is_const> {
+            using type = T;
+        };
     }
 
     struct PropertyException : public il2cpp_utils::exceptions::StackTraceException {
@@ -50,6 +76,19 @@ namespace bs_hook {
             if (!res) throw PropertyException(std::string("Failed to get instance property: ") + name.data.data());
             return *res;
         }
+
+        inline auto operator ->() const {
+            return this->operator T();
+        } 
+
+        inline auto operator *() const {
+            return this->operator T();
+        }
+
+        inline auto v() const {
+            return this->operator T();
+        }
+
         private:
         void* instance;
     };
@@ -67,6 +106,13 @@ namespace bs_hook {
         void* instance;
     };
 
+#define BINARY_OPERATOR_OP_EQ_PROP(op)      \
+template<typename U>                        \
+auto& operator op##=(const U& rhs) {        \
+    auto temp = this->operator T();         \
+    return this->operator=(temp op##= rhs); \
+}
+
     template<internal::NTTPString name, class T>
     struct InstanceProperty<name, T, true, true> {
         explicit constexpr InstanceProperty(void* inst) noexcept : instance(inst) {}
@@ -75,15 +121,41 @@ namespace bs_hook {
             if (!res) throw PropertyException(std::string("Failed to get instance property: ") + name.data.data());
             return *res;
         }
-        InstanceProperty& operator=(T&& t) {
+        InstanceProperty& operator=(T const& t) {
             auto val = reinterpret_cast<Il2CppObject*>(instance);
             auto res = il2cpp_utils::SetPropertyValue<false>(val, name.data.data(), std::forward<decltype(t)>(t));
             if (!res) throw PropertyException(std::string("Failed to set instance property: ") + name.data.data());
             return *this;
         }
+
+        inline auto operator ->() const {
+            return this->operator T();
+        } 
+
+        inline auto operator *() const {
+            return this->operator T();
+        }
+
+        inline auto v() const {
+            return this->operator T();
+        }
+
+        /* These operators forward to the ones on the underlying type */
+        BINARY_OPERATOR_OP_EQ_PROP(+);
+        BINARY_OPERATOR_OP_EQ_PROP(-);
+        BINARY_OPERATOR_OP_EQ_PROP(*);
+        BINARY_OPERATOR_OP_EQ_PROP(/);
+        BINARY_OPERATOR_OP_EQ_PROP(%);
+        BINARY_OPERATOR_OP_EQ_PROP(&);
+        BINARY_OPERATOR_OP_EQ_PROP(|);
+        BINARY_OPERATOR_OP_EQ_PROP(^);
+        BINARY_OPERATOR_OP_EQ_PROP(<<);
+        BINARY_OPERATOR_OP_EQ_PROP(>>);
+
         private:
         void* instance;
     };
+
 
     template<class T, internal::NTTPString name, bool get, bool set, auto klass_resolver>
     struct StaticProperty;
@@ -96,6 +168,18 @@ namespace bs_hook {
             auto res = il2cpp_utils::GetPropertyValue<T, false>(klass, name.data.data());
             if (!res) throw PropertyException(std::string("Failed to get static property: ") + name.data.data());
             return *res;
+        }
+
+        inline auto operator ->() const {
+            return this->operator T();
+        } 
+
+        inline auto operator *() const {
+            return this->operator T();
+        }
+
+        inline auto v() const {
+            return this->operator T();
         }
     };
 
@@ -119,41 +203,92 @@ namespace bs_hook {
             if (!res) throw PropertyException(std::string("Failed to get static property: ") + name.data.data());
             return *res;
         }
-        StaticProperty& operator=(T&& value) {
+
+        StaticProperty& operator=(T const& value) {
             auto klass = klass_resolver();
             if (!klass) throw NullException(std::string("Class for static property with name: ") + name.data.data() + " is null!");
             auto res = il2cpp_utils::SetPropertyValue<false>(klass, name.data.data(), std::forward<decltype(value)>(value));
             if (!res) throw PropertyException(std::string("Failed to set static property: ") + name.data.data());
             return *this;
         }
+
+        inline auto operator ->() const {
+            return this->operator T();
+        } 
+
+        inline auto operator *() const {
+            return this->operator T();
+        }
+
+        inline auto v() const {
+            return this->operator T();
+        }
+
+        BINARY_OPERATOR_OP_EQ_PROP(+);
+        BINARY_OPERATOR_OP_EQ_PROP(-);
+        BINARY_OPERATOR_OP_EQ_PROP(*);
+        BINARY_OPERATOR_OP_EQ_PROP(/);
+        BINARY_OPERATOR_OP_EQ_PROP(%);
+        BINARY_OPERATOR_OP_EQ_PROP(&);
+        BINARY_OPERATOR_OP_EQ_PROP(|);
+        BINARY_OPERATOR_OP_EQ_PROP(^);
+        BINARY_OPERATOR_OP_EQ_PROP(<<);
+        BINARY_OPERATOR_OP_EQ_PROP(>>);
     };
 
-    template<class T, std::size_t offset>
-    struct InstanceField;
-    
-    template<class T, std::size_t offset>
+#undef BINARY_OPERATOR_OP_EQ_PROP
+
+    template<class T, std::size_t offset, bool is_const = true>
+    requires(!std::is_reference_v<T>)
     struct InstanceField {
+        protected:
+        using Ref = typename internal::MakeWrapperRef<T, is_const>::type;
+        using Ptr = typename internal::MakeWrapperPtr<T, is_const>::type;
+        void* getAtOffset() const {
+            return reinterpret_cast<uint8_t*>(const_cast<void*>(instance)) + offset;
+        }
+        public:
         explicit constexpr InstanceField(void* inst) noexcept : instance(inst) {}
-        operator T() const {
+        operator Ref () const {
             if (instance == nullptr) throw NullException("Instance field access failed at offset: " + std::to_string(offset) + " because instance was null!");
             // No wbarrier required for unilateral gets
             if constexpr (il2cpp_utils::has_il2cpp_conversion<T>) {
                 // Handle wrapper types differently
-                return T(*reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(const_cast<void*>(instance)) + offset));
+                return T(*reinterpret_cast<void**>(getAtOffset()));
             }
-            return *reinterpret_cast<T*>(reinterpret_cast<uint8_t*>(const_cast<void*>(instance)) + offset);
+            return *reinterpret_cast<T*>(getAtOffset());
         }
 
-        inline T operator *() const {
-            return this->operator T();
+        Ptr operator ->() const {
+            if (instance == nullptr) throw NullException("Instance field access failed at offset: " + std::to_string(offset) + " because instance was null!");
+            if constexpr (il2cpp_utils::has_il2cpp_conversion<T>) {
+                return this->operator T();
+            }
+            return const_cast<Ptr>(reinterpret_cast<T*>(getAtOffset()));
+        } 
+
+        inline auto operator *() const {
+            return this->operator Ref();
         }
+
+        inline auto v() const {
+            return this->operator Ref();
+        }
+
         private:
         void* instance;
     };
 
+#define BINARY_OPERATOR_OP_EQ_FIELD(op)     \
+template<typename U>                        \
+auto& operator op##=(const U& rhs) {        \
+    this->operator Ref() op##= rhs;         \
+    return *this;                           \
+}
+
     template<class T, std::size_t offset>
-    struct AssignableInstanceField : public InstanceField<T, offset> {
-        explicit constexpr AssignableInstanceField(void* inst) noexcept : InstanceField<T, offset>(inst) {}
+    struct AssignableInstanceField : public InstanceField<T, offset, false> {
+        using InstanceField<T, offset, false>::InstanceField;
         AssignableInstanceField& operator=(T&& t) {
             if (instance == nullptr) throw NullException("Instance field assignment failed at offset: " + std::to_string(offset) + " because instance was null!");
             
@@ -161,26 +296,45 @@ namespace bs_hook {
                 // We only do this if we are a wrapper type!
                 il2cpp_functions::Init();
                 // instance is actually unused for wbarrier, wbarrier call performs the assignment
-                il2cpp_functions::gc_wbarrier_set_field(instance, reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(instance) + offset), t.convert());
+                il2cpp_functions::gc_wbarrier_set_field(instance, reinterpret_cast<void**>(InstanceField<T, offset, false>::getAtOffset()), t.convert());
             } else {
                 // No wbarrier for types that are not wrapper types
                 // TODO: Value types ALSO need a wbarrier, but for the whole size of themselves.
                 // We need to xref trace to find the correct wbarrier set in this case, or call the set_field directly...
                 // Which is a bit of a pain.
-                *reinterpret_cast<T*>(reinterpret_cast<uint8_t*>(instance) + offset) = t;
+                *reinterpret_cast<T*>(InstanceField<T, offset, false>::getAtOffset()) = t;
             }
             return *this;
         }
+
+        BINARY_OPERATOR_OP_EQ_FIELD(+);
+        BINARY_OPERATOR_OP_EQ_FIELD(-);
+        BINARY_OPERATOR_OP_EQ_FIELD(*);
+        BINARY_OPERATOR_OP_EQ_FIELD(/);
+        BINARY_OPERATOR_OP_EQ_FIELD(%);
+        BINARY_OPERATOR_OP_EQ_FIELD(&);
+        BINARY_OPERATOR_OP_EQ_FIELD(|);
+        BINARY_OPERATOR_OP_EQ_FIELD(^);
+        BINARY_OPERATOR_OP_EQ_FIELD(<<);
+        BINARY_OPERATOR_OP_EQ_FIELD(>>);
+
         private:
         void* instance;
+        using Ref = typename InstanceField<T, offset, false>::Ref;
     };
 
-    template<class T, internal::NTTPString name, auto klass_resolver>
-    struct StaticField;
+#undef BINARY_OPERATOR_OP_EQ_FIELD
+
+
+#define BINARY_OPERATOR_OP_EQ_STATIC_FIELD(op)  \
+template<typename U>                            \
+auto& operator op##=(const U& rhs) {            \
+    auto temp = this->operator T();             \
+    return this->operator =(temp op##= rhs);    \
+}
 
     // Static fields all have proper wbarriers through using set field API calls
-    
-    template<class T, internal::NTTPString name, auto klass_resolver>
+    template<class T, internal::NTTPString name, auto klass_resolver, bool is_const = true>
     struct StaticField {
         operator T() const {
             auto klass = klass_resolver();
@@ -190,13 +344,21 @@ namespace bs_hook {
             return *val;
         }
 
-        inline T operator *() {
-            return static_cast<T>(*this);
+        inline auto operator ->() const {
+            return this->operator T();
+        } 
+
+        inline auto operator *() const {
+            return this->operator T();
+        }
+
+        inline auto v() const {
+            return this->operator T();
         }
     };
 
     template<class T, internal::NTTPString name, auto klass_resolver>
-    struct AssignableStaticField : public StaticField<T, name, klass_resolver> {
+    struct AssignableStaticField : public StaticField<T, name, klass_resolver, false> {
         AssignableStaticField& operator=(T&& value) {
             auto klass = klass_resolver();
             if (!klass) throw NullException(std::string("Class for static field with name: ") + name.data.data() + " is null!");
@@ -204,5 +366,19 @@ namespace bs_hook {
             if (!val) throw FieldException(std::string("Could not set static field with name: ") + name.data.data());
             return *this;
         }
+
+        BINARY_OPERATOR_OP_EQ_STATIC_FIELD(+);
+        BINARY_OPERATOR_OP_EQ_STATIC_FIELD(-);
+        BINARY_OPERATOR_OP_EQ_STATIC_FIELD(*);
+        BINARY_OPERATOR_OP_EQ_STATIC_FIELD(/);
+        BINARY_OPERATOR_OP_EQ_STATIC_FIELD(%);
+        BINARY_OPERATOR_OP_EQ_STATIC_FIELD(&);
+        BINARY_OPERATOR_OP_EQ_STATIC_FIELD(|);
+        BINARY_OPERATOR_OP_EQ_STATIC_FIELD(^);
+        BINARY_OPERATOR_OP_EQ_STATIC_FIELD(<<);
+        BINARY_OPERATOR_OP_EQ_STATIC_FIELD(>>);
     };
+
+#undef BINARY_OPERATOR_OP_EQ_STATIC_FIELD
+
 }

--- a/shared/utils/base-wrapper-type.hpp
+++ b/shared/utils/base-wrapper-type.hpp
@@ -19,9 +19,17 @@ namespace bs_hook {
     /// All other wrapper types should inherit from this or otherwise satisfy the constraint above.
     struct Il2CppWrapperType {
         constexpr explicit Il2CppWrapperType(void* i) noexcept : instance(i) {}
+        constexpr Il2CppWrapperType(Il2CppWrapperType const& other) = default;
+        constexpr Il2CppWrapperType(Il2CppWrapperType && other) = default;
+        constexpr Il2CppWrapperType& operator=(Il2CppWrapperType const& other) = default;
+        constexpr Il2CppWrapperType& operator=(Il2CppWrapperType && other) = default;
+
         constexpr void* convert() const noexcept {
             return const_cast<void*>(instance);
         }
+
+        operator Il2CppObject*() { return const_cast<Il2CppObject*>(static_cast<Il2CppObject*>(instance)); }
+
         protected:
         void* instance;
     };

--- a/shared/utils/base-wrapper-type.hpp
+++ b/shared/utils/base-wrapper-type.hpp
@@ -28,7 +28,7 @@ namespace bs_hook {
             return const_cast<void*>(instance);
         }
 
-        operator Il2CppObject*() { return const_cast<Il2CppObject*>(static_cast<Il2CppObject*>(instance)); }
+        operator Il2CppObject*() const noexcept { return const_cast<Il2CppObject*>(static_cast<Il2CppObject const*>(instance)); }
 
         protected:
         void* instance;

--- a/src/tests/accessor-wrapper-tests.cpp
+++ b/src/tests/accessor-wrapper-tests.cpp
@@ -5,6 +5,10 @@
 #include <iostream>
 
 
+struct Delegate {
+    void operator()(int a) { a += 5;}
+};
+
 struct Color {
     float r, g, b, a;
     Color& operator +=(const Color& rhs) {
@@ -25,6 +29,7 @@ struct Underlying {
     int b;
     int c;
     Color d;
+    Delegate e;
 };
 
 struct Test;
@@ -56,6 +61,7 @@ struct Test {
     bs_hook::InstanceProperty<"B", Color, true, true> colorProp{instance};
     bs_hook::AssignableInstanceField<int, 0x8> c{instance};
     bs_hook::AssignableInstanceField<Color, 0x16> mycol{instance};
+    bs_hook::AssignableInstanceField<Delegate, 0x20> delegate{instance};
     static inline bs_hook::AssignableStaticField<int, "staticA", &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticA;
     static inline bs_hook::StaticField<int, "staticA2", &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticA2;
     static inline bs_hook::StaticProperty<int, "staticProp", true, true, &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticB;
@@ -69,6 +75,8 @@ int main() {
     t.B = 0x1234;
     std::cout << std::endl;
     t.c = 123;
+    t.c++;
+    t.c--;
     std::cout << "A: " << t.A << " B: " << t.B << " c: " << t.c << std::endl;
     t.assign(new Underlying());
     std::cout << "A: " << t.A << " B: " << t.B << " c: " << t.c << std::endl;
@@ -81,6 +89,7 @@ int main() {
     t.mycol += Color{1, 2, 3, 4};
     t.colorProp->g = -5.0f;
     t.colorProp += Color{1, 2, 3, 4};
+    t.delegate(4);
     // Test::staticA2 = 123; // INVALID!
     // Test::staticProp2 = 123; // INVALID!
     // Test::staticB = Test::staticProp3; // INVALID!

--- a/src/tests/accessor-wrapper-tests.cpp
+++ b/src/tests/accessor-wrapper-tests.cpp
@@ -37,9 +37,9 @@ struct Test {
     public:
     bs_hook::InstanceProperty<"A", int, true, true> A{instance};
     bs_hook::InstanceProperty<"B", int, true, true> B{instance};
-    bs_hook::InstanceField<int, 0x8, true> c{instance};
-    static inline bs_hook::StaticField<int, "staticA", true, &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticA;
-    static inline bs_hook::StaticField<int, "staticA2", false, &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticA2;
+    bs_hook::AssignableInstanceField<int, 0x8> c{instance};
+    static inline bs_hook::AssignableStaticField<int, "staticA", &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticA;
+    static inline bs_hook::StaticField<int, "staticA2", &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticA2;
     static inline bs_hook::StaticProperty<int, "staticProp", true, true, &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticB;
     static inline bs_hook::StaticProperty<int, "staticProp2", true, false, &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticProp2;
     static inline bs_hook::StaticProperty<int, "staticProp3", false, true, &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticProp3;

--- a/src/tests/accessor-wrapper-tests.cpp
+++ b/src/tests/accessor-wrapper-tests.cpp
@@ -75,9 +75,11 @@ struct Test {
 int main() {
     Test t(new Underlying());
     t.A = 0x4567;
+    t.A = 5.0f;
     t.B = 0x1234;
     std::cout << std::endl;
     t.c = 123;
+    t.c = 2.0f;
     t.c++;
     t.c--;
     std::cout << "A: " << t.A << " B: " << t.B << " c: " << t.c << std::endl;
@@ -86,7 +88,9 @@ int main() {
     // return t.A == t.B;
     // return t.c;
     Test::staticA = 456;
+    Test::staticA = 456.0f;
     Test::staticB = 789;
+    Test::staticB = 500.0f;
     Test::staticA = Test::staticB;
     t.mycol->r = 5.0f;
     t.mycol += Color{1, 2, 3, 4};
@@ -96,6 +100,18 @@ int main() {
     // Test::staticA2 = 123; // INVALID!
     // Test::staticProp2 = 123; // INVALID!
     // Test::staticB = Test::staticProp3; // INVALID!
+
+    int x = 3;
+    float y = 1.0f;
+    t.A = x;
+    t.A = y;
+    t.c = x;
+    t.c = y;
+    t.staticA = x;
+    t.staticA = y;
+    t.staticB = x;
+    t.staticB = y;
+
     return t.A == 0x4567 && t.B == 0x1234 && t.c == 123;
 }
 #endif

--- a/src/tests/accessor-wrapper-tests.cpp
+++ b/src/tests/accessor-wrapper-tests.cpp
@@ -6,7 +6,10 @@
 
 
 struct Delegate {
-    void operator()(int a) { a += 5;}
+    void operator()(int a) { 
+        value = a;
+    }
+    int value;
 };
 
 struct Color {

--- a/src/tests/accessor-wrapper-tests.cpp
+++ b/src/tests/accessor-wrapper-tests.cpp
@@ -5,10 +5,26 @@
 #include <iostream>
 
 
+struct Color {
+    float r, g, b, a;
+    Color& operator +=(const Color& rhs) {
+        r += rhs.r;
+        g += rhs.g;
+        b += rhs.b;
+        a += rhs.a;
+        return *this;
+    }
+
+    Color* operator ->() {
+        return this;
+    }
+};
+
 struct Underlying {
     int a;
     int b;
     int c;
+    Color d;
 };
 
 struct Test;
@@ -37,7 +53,9 @@ struct Test {
     public:
     bs_hook::InstanceProperty<"A", int, true, true> A{instance};
     bs_hook::InstanceProperty<"B", int, true, true> B{instance};
+    bs_hook::InstanceProperty<"B", Color, true, true> colorProp{instance};
     bs_hook::AssignableInstanceField<int, 0x8> c{instance};
+    bs_hook::AssignableInstanceField<Color, 0x16> mycol{instance};
     static inline bs_hook::AssignableStaticField<int, "staticA", &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticA;
     static inline bs_hook::StaticField<int, "staticA2", &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticA2;
     static inline bs_hook::StaticProperty<int, "staticProp", true, true, &::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<Test>::get> staticB;
@@ -59,6 +77,10 @@ int main() {
     Test::staticA = 456;
     Test::staticB = 789;
     Test::staticA = Test::staticB;
+    t.mycol->r = 5.0f;
+    t.mycol += Color{1, 2, 3, 4};
+    t.colorProp->g = -5.0f;
+    t.colorProp += Color{1, 2, 3, 4};
     // Test::staticA2 = 123; // INVALID!
     // Test::staticProp2 = 123; // INVALID!
     // Test::staticB = Test::staticProp3; // INVALID!


### PR DESCRIPTION
 - ctors for field and property wrappers are now constexpr
 - Fields have a regular and assignable type now, using inheritance
 - operator -> can be used to bypass the field wrapper and access the wrapped type directly
 - operator @=, increment, decrement and () are supported
 - Updated tests to reflect these additions