### PR TITLE
Add null check to string_view

### DIFF
--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -87,7 +87,7 @@ namespace il2cpp_utils {
         // if null string input,
         // return an empty allocated il2cpp string
         if (inp.data() == nullptr) {
-            return newcsstr<creationType>("");
+            return newcsstr<creationType>(u"");
         }
 
         if constexpr (creationType == CreationType::Manual) {

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -83,6 +83,13 @@ namespace il2cpp_utils {
     template<CreationType creationType = CreationType::Temporary>
     Il2CppString* newcsstr(std::u16string_view inp) {
         il2cpp_functions::Init();
+
+        // if null string input,
+        // return an empty allocated il2cpp string
+        if (inp.data() == nullptr) {
+            return newcsstr<creationType>("");
+        }
+
         if constexpr (creationType == CreationType::Manual) {
             auto len = inp.length();
             auto mallocSize = sizeof(Il2CppString) + sizeof(Il2CppChar) * (len + 1);
@@ -108,6 +115,13 @@ namespace il2cpp_utils {
     template<CreationType creationType = CreationType::Temporary>
     Il2CppString* newcsstr(std::string_view inp) {
         il2cpp_functions::Init();
+
+        // if null string input,
+        // return an empty allocated il2cpp string
+        if (inp.data() == nullptr) {
+            return newcsstr<creationType>("");
+        }
+
         if constexpr (creationType == CreationType::Manual) {
             // TODO: Perhaps manually call createManual instead
             auto len = inp.length();

--- a/src/utils/typedefs-wrapper.cpp
+++ b/src/utils/typedefs-wrapper.cpp
@@ -44,10 +44,19 @@ std::size_t convstr(char16_t const* inp, char* outp, int isz, int osz) {
 
 Il2CppString* alloc_str(std::string_view str) {
     il2cpp_functions::Init();
+
+    if (str.data() == nullptr) {
+        return il2cpp_functions::string_new_len("\0", 0);
+    }
+
     return il2cpp_functions::string_new_len(str.data(), str.size());
 }
 Il2CppString* alloc_str(std::u16string_view str) {
     il2cpp_functions::Init();
+    if (str.data() == nullptr) {
+        return il2cpp_functions::string_new_len("\0", 0);
+    }
+
     return il2cpp_functions::string_new_utf16((Il2CppChar const*)str.data(), str.size());
 }
 

--- a/src/utils/typedefs-wrapper.cpp
+++ b/src/utils/typedefs-wrapper.cpp
@@ -46,7 +46,7 @@ Il2CppString* alloc_str(std::string_view str) {
     il2cpp_functions::Init();
 
     if (str.data() == nullptr) {
-        return il2cpp_functions::string_new_len("\0", 0);
+        return il2cpp_functions::string_new_len("", 0);
     }
 
     return il2cpp_functions::string_new_len(str.data(), str.size());
@@ -54,7 +54,7 @@ Il2CppString* alloc_str(std::string_view str) {
 Il2CppString* alloc_str(std::u16string_view str) {
     il2cpp_functions::Init();
     if (str.data() == nullptr) {
-        return il2cpp_functions::string_new_len("\0", 0);
+        return il2cpp_functions::string_new_len("", 0);
     }
 
     return il2cpp_functions::string_new_utf16((Il2CppChar const*)str.data(), str.size());


### PR DESCRIPTION
There's a chance for undefined behaviour in il2cpp string allocations when the given string is null. This attempts to make it more explicit what should occur.